### PR TITLE
[AUTH-1434] Update existing automated IdP tests to meet current manual tests PWD-1 thru PWD-9

### DIFF
--- a/tests/test_password_sign_on.py
+++ b/tests/test_password_sign_on.py
@@ -57,8 +57,8 @@ def crazy_casing(netid: str) -> str:
     return ''.join(letters)
 
 
-def test_pwd_1_2_3(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
-    # 1
+def test_new_session_standard___existing_sso_session(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
+    # 1 New session, standard sign-in
     password = secrets.test_accounts.password
     sp = ServiceProviderInstance.diafine8
     with utils.using_test_sp(sp):
@@ -67,7 +67,7 @@ def test_pwd_1_2_3(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
         browser.click(Locators.submit_button)
         browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
 
-    # 2
+    # 2 Use existing pwd SSO session for sign-in
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
         new_tab()
@@ -84,7 +84,8 @@ def test_pwd_1_2_3(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
         browser.close()
 
 
-def test_pwd_4(utils, browser, sp_url, secrets, netid):
+def test_new_session_standard_bad_creds(utils, browser, sp_url, secrets, netid):
+    # 4 New session, standard sign-in, bad creds
     fresh_browser = Chrome()
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
@@ -104,7 +105,8 @@ def test_pwd_4(utils, browser, sp_url, secrets, netid):
         fresh_browser.close()
 
 
-def test_pwd_5(utils, browser, sp_url, secrets, netid, sp_domain, new_tab):
+def test_existing_sso_for_sign_in_with_forced_reauth(utils, browser, sp_url, secrets, netid, sp_domain, new_tab):
+    # 5 Use existing pwd SSO session for sign-in, combined with forced reauth
     fresh_browser = Chrome()
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
@@ -125,7 +127,8 @@ def test_pwd_5(utils, browser, sp_url, secrets, netid, sp_domain, new_tab):
         fresh_browser.close()
 
 
-def test_pwd_6(browser, netid, utils, sp_url, secrets, sp_domain):
+def test_idp_initiated_sign_in(browser, netid, utils, sp_url, secrets, sp_domain):
+    # 6 IdP-initiated sign-in
     fresh_browser = Chrome()
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
@@ -149,7 +152,8 @@ def test_pwd_6(browser, netid, utils, sp_url, secrets, sp_domain):
     partial(add_suffix, '@uw.edu'),
     partial(add_suffix, '@google.com')
 ])
-def test_pwd_7(browser, netid, utils, sp_url, secrets, sp_domain, login_transform):
+def test_new_session_sign_on_domain_credential(browser, netid, utils, sp_url, secrets, sp_domain, login_transform):
+    # 7 New session, sign on with @domain credential format
     fresh_browser = Chrome()
     login = login_transform(netid)
     password = secrets.test_accounts.password
@@ -159,16 +163,15 @@ def test_pwd_7(browser, netid, utils, sp_url, secrets, sp_domain, login_transfor
         fresh_browser.send_inputs(login, password)
         fresh_browser.click(Locators.submit_button)
         if 'google' not in login:
-            print('not google')
             fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
         else:
-            print('google')
             element = fresh_browser.wait_for_tag('p', 'Please sign in with your')
             assert ('Please sign in with your UW NetID' in element.text)
     fresh_browser.close()
 
 
-def test_pwd_8_9(browser, netid, utils, sp_url, secrets, sp_domain):
+def test_case_insensitivity___query_parameters(browser, netid, utils, sp_url, secrets, sp_domain):
+    # 8 Case insensitivity
     fresh_browser = Chrome()
     password = secrets.test_accounts.password
     sp = ServiceProviderInstance.diafine6
@@ -178,7 +181,7 @@ def test_pwd_8_9(browser, netid, utils, sp_url, secrets, sp_domain):
         fresh_browser.send_inputs(crazy_netid, password)
         fresh_browser.click(Locators.submit_button)
         fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
-        # 9
+        # 9 Query parameters
         fresh_browser.get(f'{sp_url(sp)}/shibprod/q-param-test.aspx?fname=Joe&lname=Smith&age=30')
         fresh_browser.wait_for_tag('h1', 'query parameters')
         element = fresh_browser.find_elements_by_tag_name('p')

--- a/tests/test_password_sign_on.py
+++ b/tests/test_password_sign_on.py
@@ -71,11 +71,12 @@ class TestNewSessionAndExistingSSOSession:
     The two tests are grouped here only because they need to share the same browser instance.
     """
     @pytest.fixture(autouse=True)
-    def initialize(self, class_browser, utils, sp_url, netid, new_tab, sp_domain):
+    def initialize(self, class_browser, utils, sp_url, sp_domain, new_tab):
         self.browser = class_browser
         self.utils = utils
         self.sp_url = sp_url
         self.sp_domain = sp_domain
+        self.new_tab = new_tab
 
     def test_new_session_standard(self, secrets, netid):
         # 1 New session, standard sign-in
@@ -87,11 +88,11 @@ class TestNewSessionAndExistingSSOSession:
             self.browser.click(Locators.submit_button)
             self.browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
 
-    def test_existing_sso_session(self, new_tab):
+    def test_existing_sso_session(self):
         # 2 Use existing pwd SSO session for sign-in
         sp = ServiceProviderInstance.diafine6
         with self.utils.using_test_sp(sp):
-            new_tab()
+            self.new_tab()
             with self.browser.autocapture_off():
                 self.browser.get(f'{self.sp_url(sp)}/shibprod')
             self.browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
@@ -102,9 +103,7 @@ class TestNewSessionAndExistingSSOSession:
                 self.browser.wait_for_tag('h1', 'Diafine6 IdP Testing Platform')
             self.browser.click_tag('a', 'Logout')
             self.browser.wait_for_tag('span', 'Your UW NetID sign-in session has ended')
-            self.browser.close()
 
-# def test_new_session_standard___existing_sso_session(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
 
 def test_new_session_standard_bad_creds(utils, browser, sp_url, secrets, netid):
     # 4 New session, standard sign-in, bad creds
@@ -204,7 +203,7 @@ class TestNetIDCaseInsensitivityAndURLQueryParams:
         self.utils = utils
         self.sp_url = sp_url
 
-    def test_case_insensitivity(self, netid, secrets, sp_domain):
+    def test_case_insensitivity(self, netid, sp_domain):
         # 8 Case insensitivity
         crazy_netid = crazy_casing(netid)
         with self.utils.using_test_sp(self.sp):
@@ -213,7 +212,7 @@ class TestNetIDCaseInsensitivityAndURLQueryParams:
             self.browser.click(Locators.submit_button)
             self.browser.wait_for_tag('h2', f'{sp_domain(self.sp)} sign-in success!')
 
-    def test_query_parameters(self,  netid, secrets, sp_domain):
+    def test_query_parameters(self,  netid):
         # 9 Query parameters
         with self.utils.using_test_sp(self.sp):
             self.browser.snap()

--- a/tests/test_password_sign_on.py
+++ b/tests/test_password_sign_on.py
@@ -1,5 +1,11 @@
+"""
+This set of tests is based on the manual tests here
+https://wiki.cac.washington.edu/display/SMW/Glen%27s+IdP+practice+Matrix
+PWD-1 thru PWD-9.
+"""
+
+
 from functools import partial
-from typing import Callable
 
 import pytest
 from webdriver_recorder.browser import Chrome
@@ -16,7 +22,8 @@ def browser() -> Chrome:
 @pytest.fixture
 def new_tab(browser):
     def inner():
-        browser.find_element_by_tag_name('body').send_keys(CTRL_KEY + 't')
+        browser.execute_script("window.open('');")
+        browser.switch_to.window(browser.window_handles[-1])
     return inner
 
 
@@ -50,100 +57,130 @@ def crazy_casing(netid: str) -> str:
     return ''.join(letters)
 
 
-# PWD 1–4, 6–8, 10
+def test_pwd_1_2_3(utils, browser, sp_url, sp_domain, new_tab, secrets, netid):
+    # 1
+    password = secrets.test_accounts.password
+    sp = ServiceProviderInstance.diafine8
+    with utils.using_test_sp(sp):
+        browser.get(f'{sp_url(sp)}/shibprod')
+        browser.send_inputs(netid, password)
+        browser.click(Locators.submit_button)
+        browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+
+    # 2
+    sp = ServiceProviderInstance.diafine6
+    with utils.using_test_sp(sp):
+        new_tab()
+        with browser.autocapture_off():
+            browser.get(f'{sp_url(sp)}/shibprod')
+        browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+    # 3 logout and close browser
+        with browser.autocapture_off():
+            browser.click_tag('a', 'Return to the main menu')
+        with browser.autocapture_off():
+            browser.wait_for_tag('h1', 'Diafine6 IdP Testing Platform')
+        browser.click_tag('a', 'Logout')
+        browser.wait_for_tag('span', 'Your UW NetID sign-in session has ended')
+        browser.close()
+
+
+def test_pwd_4(utils, browser, sp_url, secrets, netid):
+    fresh_browser = Chrome()
+    sp = ServiceProviderInstance.diafine6
+    with utils.using_test_sp(sp):
+        fresh_browser.get(f'{sp_url(sp)}/shibprod')
+        password = secrets.test_accounts.password
+        badnetid = 'non-existant-0123456789'
+        fresh_browser.send_inputs(badnetid, password)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('p', 'Your sign-in failed.')
+        element = fresh_browser.find_element_by_id('weblogin_netid')
+        element.click()
+        element.clear()
+        badpassword = '1'
+        fresh_browser.send_inputs(netid, badpassword)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('p', 'Your sign-in failed.')
+        fresh_browser.close()
+
+
+def test_pwd_5(utils, browser, sp_url, secrets, netid, sp_domain, new_tab):
+    fresh_browser = Chrome()
+    sp = ServiceProviderInstance.diafine6
+    with utils.using_test_sp(sp):
+        fresh_browser.get(f'{sp_url(sp)}/shibprod')
+        password = secrets.test_accounts.password
+        fresh_browser.send_inputs(netid, password)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+
+    sp = ServiceProviderInstance.diafine8
+    with utils.using_test_sp(sp):
+        new_tab()
+        fresh_browser.get(f'{sp_url(sp)}/shibprodforce')
+        password = secrets.test_accounts.password
+        fresh_browser.send_inputs(netid, password)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+        fresh_browser.close()
+
+
+def test_pwd_6(browser, netid, utils, sp_url, secrets, sp_domain):
+    fresh_browser = Chrome()
+    sp = ServiceProviderInstance.diafine6
+    with utils.using_test_sp(sp):
+        fresh_browser.get('https://idp.u.washington.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=https://diafine6'
+                          '.sandbox.iam.s.uw.edu/shibboleth&shire=https://diafine6.sandbox.iam.s.uw.edu/Shibboleth'
+                          '.sso/SAML2/POST')
+        password = secrets.test_accounts.password
+        fresh_browser.send_inputs(netid, password)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('h1', 'Diafine6 IdP Testing Platform')
+        fresh_browser.get('https://diafine6.sandbox.iam.s.uw.edu/Shibboleth.sso/Session')
+        fresh_browser.wait_for_tag('u', 'Miscellaneous')
+        with fresh_browser.autocapture_off():
+            fresh_browser.wait_for_tag('strong', 'Session Expiration (barring inactivity):')
+    fresh_browser.close()
+
+
 @pytest.mark.parametrize('login_transform', [
-    lambda n: n,
     partial(add_suffix, '@u.washington.edu'),
     partial(add_suffix, '@washington.edu'),
     partial(add_suffix, '@uw.edu'),
-    crazy_casing,
+    partial(add_suffix, '@google.com')
 ])
-def test_new_session_std_sign_on(utils, browser, sp_url, sp_domain, new_tab, secrets, netid, login_transform):
+def test_pwd_7(browser, netid, utils, sp_url, secrets, sp_domain, login_transform):
+    fresh_browser = Chrome()
     login = login_transform(netid)
     password = secrets.test_accounts.password
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
-        browser.get(f'{sp_url(sp)}/shibprod')
-        browser.send_inputs(login, password)
-        browser.click(Locators.submit_button)
-        browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
-
-    sp = ServiceProviderInstance.diafine12
-    with utils.using_test_sp(sp):
-        new_tab()
-        browser.get(f'{sp_url(sp)}/shibprod')
-        browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
-
-    sp = ServiceProviderInstance.diafine6
-    with utils.using_test_sp(sp):
-        new_tab()
-        browser.get(f'{sp_url(sp)}/shibprodforce')
-        browser.send_inputs(netid, password)
-        browser.click(Locators.submit_button)
-        browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
-        browser.click(Locators.logout_button)
-        browser.wait_for_tag('span', 'your uw netid sign-in session has ended.')
+        fresh_browser.get(f'{sp_url(sp)}/shibprod')
+        fresh_browser.send_inputs(login, password)
+        fresh_browser.click(Locators.submit_button)
+        if 'google' not in login:
+            print('not google')
+            fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+        else:
+            print('google')
+            element = fresh_browser.wait_for_tag('p', 'Please sign in with your')
+            assert ('Please sign in with your UW NetID' in element.text)
+    fresh_browser.close()
 
 
-# PWD 5
-def test_idp_initiated_sign_on(utils, browser, sp_url, sp_domain, secrets, netid):
-    sp = ServiceProviderInstance.diafine6
+def test_pwd_8_9(browser, netid, utils, sp_url, secrets, sp_domain):
+    fresh_browser = Chrome()
     password = secrets.test_accounts.password
-    url = ("https://idp.u.washington.edu/idp/profile/SAML2/Unsolicited/SSO?providerId="
-           f"{sp_url(sp)}/shibboleth&shire={sp_url(sp)}/Shibboleth.sso/SAML2/POST")
-    with utils.using_test_sp(sp):
-        browser.get(url)
-        browser.send_inputs(netid, password)
-        browser.click(Locators.submit_button)
-        browser.wait_for_tag('h1', 'diafine6 idp testing platform')
-
-
-# PWD 9, 12, 13
-@pytest.mark.parametrize('login_transform, password_transform, expected_error_message', [
-    # Adds an unsupported suffix to the user's netid
-    (partial(add_suffix, '@google.com'), lambda p: p, 'please sign in with your uw netid'),
-    # Transforms the user's netid to become one that doesn't exist
-    (partial(add_suffix, 'zzz'), lambda p: p, 'your sign-in failed'),
-    # Reverses the user's password, so that it is incorrect
-    (lambda n: n, lambda p: p[::-1], 'your sign-in failed'),
-])
-def test_password_sign_on_fails(
-        utils: WebTestUtils,
-        browser: Chrome,
-        sp_url: Callable[[ServiceProviderInstance], str],
-        secrets: TestSecrets,
-        netid: str,
-        login_transform: Callable[[str], str],
-        password_transform: Callable[[str], str],
-        expected_error_message: str):
-    """
-    :param login_transform: A function that accepts a string, and returns a string.
-    :param password_transform:  A function that accepts a string, and returns a string.
-    """
-    login = login_transform(netid)
     sp = ServiceProviderInstance.diafine6
-    password = password_transform(secrets.test_accounts.password)
-
+    crazy_netid = crazy_casing(netid)
     with utils.using_test_sp(sp):
-        browser.get(f'{sp_url(sp)}/shibprod')
-        browser.send_inputs(login, password)
-        browser.click(Locators.submit_button)
-        browser.wait_for_tag('p', expected_error_message)
-
-
-# PWD 11
-def test_query_param_forwarding(utils: WebTestUtils, browser: Chrome, sp_url: Callable[[ServiceProviderInstance], str],
-                                secrets: TestSecrets, netid: str):
-    sp = ServiceProviderInstance.diafine6
-    password = secrets.test_accounts.password
-
-    with utils.using_test_sp(sp):
-
-        browser.get(f'{sp_url(sp)}/shibprod/q-param-test.aspx?fname=Joe&lname=Smith&age=30')
-        browser.send_inputs(netid, password)
-        browser.click(Locators.submit_button)
-        browser.wait_for_tag('h1', 'query parameters')
-        paragraphs = browser.find_elements_by_tag_name('p')
-        assert 'this page should display all parameters from the query string' in paragraphs[0].text
+        fresh_browser.get(f'{sp_url(sp)}/shibprod')
+        fresh_browser.send_inputs(crazy_netid, password)
+        fresh_browser.click(Locators.submit_button)
+        fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
+        # 9
+        fresh_browser.get(f'{sp_url(sp)}/shibprod/q-param-test.aspx?fname=Joe&lname=Smith&age=30')
+        fresh_browser.wait_for_tag('h1', 'query parameters')
+        element = fresh_browser.find_elements_by_tag_name('p')
         for snippet in ('fname = Joe', 'lname = Smith', 'age = 30'):
-            assert snippet in paragraphs[1].text
+            assert (snippet in element[1].text)


### PR DESCRIPTION
- Before we can expand our automated IdP test collection, it was discovered the existing ones needed to be updated first as the manual tests that drive them have changed.
- This set of tests is based on the manual tests here https://wiki.cac.washington.edu/display/SMW/Glen%27s+IdP+practice+Matrix (PWD-1 thru PWD-9).
- Closes [AUTH-1434](https://jira.cac.washington.edu/browse/AUTH-1434)
- Prior to merging I will check in with @mbrogan2 on the changes presented in this PR.