### PR TITLE
Closes several JIRAs related to AUTH-1437 (Expand automated test coverage)

### DIFF
--- a/docs/settings-and-options.md
+++ b/docs/settings-and-options.md
@@ -17,6 +17,13 @@ The order of precedence becomes:
 To that end, it's important to remember that "settings" can only be controlled via yaml, but "options" can be 
 toggled at the command line.
 
+## Running against prod or eval
+
+The tests can be run against the production environment or the test/eval environment
+To run the tests against production use the command line argument `--env=prod`
+To run the tests against production use the command line argument `--env=eval`
+If you do not use the `--env` flag, the tests will run against production as default.
+
 ## Switching profiles
 
 If you want to run tests using a different set of settings, you can override this two ways.

--- a/docs/settings-and-options.md
+++ b/docs/settings-and-options.md
@@ -21,7 +21,7 @@ toggled at the command line.
 
 The tests can be run against the production environment or the test/eval environment
 To run the tests against production use the command line argument `--env=prod`
-To run the tests against production use the command line argument `--env=eval`
+To run the tests against eval use the command line argument `--env=eval`
 If you do not use the `--env` flag, the tests will run against production as default.
 
 ## Switching profiles

--- a/tests/access_control/test_auto_2fa.py
+++ b/tests/access_control/test_auto_2fa.py
@@ -3,14 +3,6 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-def test_me(my_fixture):
-    result1 = my_fixture(2, 3)
-    assert result1 == 6
-
-    result2 = my_fixture(4, 5)
-    assert result2 == 20
-
-
 class TestAuto2fa:
     @pytest.fixture(autouse=True)
     def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form):
@@ -25,9 +17,8 @@ class TestAuto2fa:
 
     def test_auto_2fa_a(self, netid3):
         """
-        AC-1 Part A
+        AC-1 Part A. Prompted for pwd then 2FA on diafine7.
         """
-        # Prompted for pwd then 2FA on diafine7.
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine7
         with self.utils.using_test_sp(sp):
@@ -40,9 +31,8 @@ class TestAuto2fa:
 
     def test_auto_2fa_b(self, netid3):
         """
-        AC-1 Part B
+        AC-1 Part B. Prompted for 2FA only on diafine7.
         """
-        # b. Prompted for 2FA only on diafine7.
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
         with self.utils.using_test_sp(sp):
@@ -58,9 +48,9 @@ class TestAuto2fa:
 
     def test_auto_2fa_c(self, netid3):
         """
-        AC-1 Part C
+        AC-1 Part C. Prompted for pwd then 2FA on diafine7.
         """
-        # Prompted for pwd then 2FA on diafine7.
+        #
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
         with self.utils.using_test_sp(sp):
@@ -78,9 +68,8 @@ class TestAuto2fa:
 
     def test_auto_2fa_d(self, netid3):
         """
-        AC-1 Part D
+        AC-1 Part D. No prompts on diafine7.
         """
-        # d. No prompts on diafine7.
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
         with self.utils.using_test_sp(sp):
@@ -97,9 +86,8 @@ class TestAuto2fa:
 
     def test_auto_2fa_e(self, netid3):
         """
-        AC-1 Part E
+        AC-1 Part E. Prompted for pwd then 2FA on diafine7.
         """
-        # Prompted for pwd then 2FA on diafine7.
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
         with self.utils.using_test_sp(sp):
@@ -118,11 +106,8 @@ class TestAuto2fa:
 
     def test_auto_2fa_f(self, netid3):
         """
-        AC-1 Part F
+        AC-1 Part F. Prompted for pwd then 2FA on diafine7 (no 500 error).
         """
-        # f. Start new 2FA session at https://diafine7.sandbox.iam.s.uw.edu/shibevalmfa.
-        # Close browser.
-        # Prompted for pwd then 2FA on diafine7 (no 500 error).
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine7
         with self.utils.using_test_sp(sp):

--- a/tests/access_control/test_auto_2fa_cond_member.py
+++ b/tests/access_control/test_auto_2fa_cond_member.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestCondAccessMember:
     @pytest.fixture(autouse=True)
     def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-4.1	Auto 2FA + conditional access, tester is group member.
+        diafine10, sptest07
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -22,19 +22,23 @@ class TestCondAccessGroupMember:
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        a. Prompted for pwd then 2FA on diafine10.
         """
         fresh_browser = Chrome()
-        sp = ServiceProviderInstance.diafine9
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
             fresh_browser.close()
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+        b. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
+        Use SSO to access https://diafine10.sandbox.iam.s.uw.edu/shibeval.
+        Close browser.
+        b. Prompted for 2FA only on diafine10.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +46,17 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+        c. Prompted for pwd then 2FA on diafine10.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,16 +64,18 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
             fresh_browser.close()
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. No prompts on diafine10.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,7 +84,8 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
@@ -83,10 +93,7 @@ class TestCondAccessGroupMember:
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd then 2FA on diafine10.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +102,24 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
+
+    def test_f(self):
+        """
+        f. Prompted for pwd then 2FA on diafine10 (no 500 error).
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine10
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()

--- a/tests/access_control/test_auto_2fa_cond_member.py
+++ b/tests/access_control/test_auto_2fa_cond_member.py
@@ -35,9 +35,6 @@ class TestCondAccessMember:
 
     def test_b(self):
         """
-        b. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
-        Use SSO to access https://diafine10.sandbox.iam.s.uw.edu/shibeval.
-        Close browser.
         b. Prompted for 2FA only on diafine10.
         """
         fresh_browser = Chrome()

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestAuto2faCondAccessNonMember:
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
+    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid3):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-4.2	Auto 2FA + conditional access, tester is not group member.
+        diafine10, sptest03
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -18,23 +18,26 @@ class TestCondAccessGroupMember:
         self.test_env = test_env
         self.two_fa_submit_form = two_fa_submit_form
         self.login_submit_form = login_submit_form
-        self.netid = netid7
+        self.netid = netid3
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        a. Prompted for pwd, then 2FA, then access denied on diafine10.
+        Access error URL returned.
         """
         fresh_browser = Chrome()
-        sp = ServiceProviderInstance.diafine9
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+         b. Prompted for 2FA then access denied on diafine10.
+        Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +45,18 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+        c. Prompted for pwd, then 2FA, then access denied on diafine10.
+         Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,16 +64,18 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. Access denied on diafine10. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,18 +84,17 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+         e. Prompted for pwd, then 2FA, then access denied on diafine10. Access error URL returned.
+         Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +103,26 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
+
+    def test_f(self):
+        """
+        f. Start new 2FA session at https://diafine10.sandbox.iam.s.uw.edu/shibevalmfa.
+        f. Prompted for pwd then 2FA, then access denied on diafine10 (no 500 error). Access error URL returned.
+        Close browser.
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine10
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -22,8 +22,7 @@ class TestAuto2faCondAccessNonMember:
 
     def test_a(self):
         """
-        a. Prompted for pwd, then 2FA, then access denied on diafine10.
-        Access error URL returned.
+        a. Prompted for pwd, then 2FA, then access denied on diafine10.  Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine10
@@ -36,8 +35,7 @@ class TestAuto2faCondAccessNonMember:
 
     def test_b(self):
         """
-         b. Prompted for 2FA then access denied on diafine10.
-        Access error URL returned.
+         b. Prompted for 2FA then access denied on diafine10.  Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -55,8 +53,7 @@ class TestAuto2faCondAccessNonMember:
 
     def test_c(self):
         """
-        c. Prompted for pwd, then 2FA, then access denied on diafine10.
-         Access error URL returned.
+        c. Prompted for pwd, then 2FA, then access denied on diafine10.  Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -94,7 +91,6 @@ class TestAuto2faCondAccessNonMember:
     def test_e(self):
         """
          e. Prompted for pwd, then 2FA, then access denied on diafine10. Access error URL returned.
-         Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -114,9 +110,7 @@ class TestAuto2faCondAccessNonMember:
 
     def test_f(self):
         """
-        f. Start new 2FA session at https://diafine10.sandbox.iam.s.uw.edu/shibevalmfa.
         f. Prompted for pwd then 2FA, then access denied on diafine10 (no 500 error). Access error URL returned.
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine10

--- a/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
+++ b/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestCond2faAccGroupNonMember2fa:
     @pytest.fixture(autouse=True)
     def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-5.3	Conditional 2FA + conditional access, tester is member of access group but is not member of 2FA group.
+        diafine11, sptest07
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -22,10 +22,10 @@ class TestCondAccessGroupMember:
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        a. Prompted for pwd on diafine11.
         """
         fresh_browser = Chrome()
-        sp = ServiceProviderInstance.diafine9
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
@@ -34,7 +34,7 @@ class TestCondAccessGroupMember:
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+        b. No prompt on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +42,19 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+        c. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
+        Use SSO to access https://diafine11.sandbox.iam.s.uw.edu/shibevalforce.
+        c. Prompted for pwd on diafine11.
+        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,7 +62,8 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
@@ -66,7 +72,7 @@ class TestCondAccessGroupMember:
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. No prompt on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,7 +81,8 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
@@ -83,10 +90,7 @@ class TestCondAccessGroupMember:
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd, then 2FA,  on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +99,25 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
+
+    def test_f(self):
+        """
+        f. Prompted for pwd, then 2FA on diafine11 (no 500 error).
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine11
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()

--- a/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
+++ b/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
@@ -51,10 +51,7 @@ class TestCond2faAccGroupNonMember2fa:
 
     def test_c(self):
         """
-        c. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
-        Use SSO to access https://diafine11.sandbox.iam.s.uw.edu/shibevalforce.
         c. Prompted for pwd on diafine11.
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6

--- a/tests/access_control/test_cond2fa_cond_member_both.py
+++ b/tests/access_control/test_cond2fa_cond_member_both.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestCond2faCondGroupMemberBoth:
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
+    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid8):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-5.1	Conditional 2FA + conditional access, tester is member of both groups.
+        diafine11, sptest08
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -18,23 +18,24 @@ class TestCondAccessGroupMember:
         self.test_env = test_env
         self.two_fa_submit_form = two_fa_submit_form
         self.login_submit_form = login_submit_form
-        self.netid = netid7
+        self.netid = netid8
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        a. Prompted for pwd then 2FA on diafine11.
         """
         fresh_browser = Chrome()
-        sp = ServiceProviderInstance.diafine9
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
             fresh_browser.close()
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+        b. Prompted for 2FA only on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +43,17 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+         c. Prompted for pwd then 2FA on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,16 +61,18 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
             fresh_browser.close()
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. No prompts on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,18 +81,16 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
-            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
             fresh_browser.close()
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd then 2FA on diafine11.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +99,26 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
+
+    def test_f(self):
+        """
+        f. Start new 2FA session at https://diafine11.sandbox.iam.s.uw.edu/shibevalmfa.
+        f. Prompted for pwd then 2FA on diafine11 (no 500 error).
+        Close browser.
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine11
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()

--- a/tests/access_control/test_cond2fa_cond_member_both.py
+++ b/tests/access_control/test_cond2fa_cond_member_both.py
@@ -110,9 +110,7 @@ class TestCond2faCondGroupMemberBoth:
 
     def test_f(self):
         """
-        f. Start new 2FA session at https://diafine11.sandbox.iam.s.uw.edu/shibevalmfa.
         f. Prompted for pwd then 2FA on diafine11 (no 500 error).
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine11

--- a/tests/access_control/test_cond2fa_cond_nonmember_both.py
+++ b/tests/access_control/test_cond2fa_cond_nonmember_both.py
@@ -23,7 +23,6 @@ class TestCond2faNonMemberBoth:
     def test_a(self):
         """
         a. Prompted for pwd, then access denied on diafine11. Access error URL returned.
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine11
@@ -52,10 +51,7 @@ class TestCond2faNonMemberBoth:
 
     def test_c(self):
         """
-        c. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
-        Use SSO to access https://diafine11.sandbox.iam.s.uw.edu/shibevalforce.
         c. Prompted for pwd, then access denied on diafine11. Access error URL returned.
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -74,7 +70,6 @@ class TestCond2faNonMemberBoth:
     def test_d(self):
         """
         d. Access denied on diafine11. Access error URL returned.
-        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -92,8 +87,7 @@ class TestCond2faNonMemberBoth:
 
     def test_e(self):
         """
-        e. Prompted for pwd, then 2FA, then access denied on diafine11.
-         Access error URL returned.
+        e. Prompted for pwd, then 2FA, then access denied on diafine11.  Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -113,8 +107,7 @@ class TestCond2faNonMemberBoth:
 
     def test_f(self):
         """
-        f. Prompted for pwd then 2FA, then access denied on diafine11 (no 500 error).
-        Access error URL returned.
+        f. Prompted for pwd then 2FA, then access denied on diafine11 (no 500 error).  Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine11
@@ -124,4 +117,3 @@ class TestCond2faNonMemberBoth:
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
-

--- a/tests/access_control/test_cond2fa_cond_nonmember_both.py
+++ b/tests/access_control/test_cond2fa_cond_nonmember_both.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestCond2faNonMemberBoth:
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
+    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid3):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-5.2	Conditional 2FA + conditional access, tester is not member of either group.
+        diafine11, sptest03
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -18,23 +18,24 @@ class TestCondAccessGroupMember:
         self.test_env = test_env
         self.two_fa_submit_form = two_fa_submit_form
         self.login_submit_form = login_submit_form
-        self.netid = netid7
+        self.netid = netid3
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        a. Prompted for pwd, then access denied on diafine11. Access error URL returned.
+        Close browser.
         """
         fresh_browser = Chrome()
-        sp = ServiceProviderInstance.diafine9
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+        b. Access denied on diafine11. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +43,19 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+        c. Start pwd SSO session at https://diafine6.sandbox.iam.s.uw.edu/shibeval.
+        Use SSO to access https://diafine11.sandbox.iam.s.uw.edu/shibevalforce.
+        c. Prompted for pwd, then access denied on diafine11. Access error URL returned.
+        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,16 +63,18 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. Access denied on diafine11. Access error URL returned.
+        Close browser.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,18 +83,17 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd, then 2FA, then access denied on diafine11.
+         Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +102,26 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-        sp = ServiceProviderInstance.diafine9
+
+        sp = ServiceProviderInstance.diafine11
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
+
+    def test_f(self):
+        """
+        f. Prompted for pwd then 2FA, then access denied on diafine11 (no 500 error).
+        Access error URL returned.
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine11
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, self.netid, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
+

--- a/tests/access_control/test_cond2fa_group_member.py
+++ b/tests/access_control/test_cond2fa_group_member.py
@@ -86,7 +86,7 @@ class TestCond2faGroupMember:
 
     def test_e(self):
         """
-        Prompted for pwd then 2FA on diafine8.
+        e. Prompted for pwd then 2FA on diafine8.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -105,7 +105,7 @@ class TestCond2faGroupMember:
 
     def test_f(self):
         """
-        Prompted for pwd then 2FA on diafine8 (no 500 error).
+        f. Prompted for pwd then 2FA on diafine8 (no 500 error).
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine8
@@ -114,8 +114,3 @@ class TestCond2faGroupMember:
             self.login_submit_form(fresh_browser, self.netid6, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
-
-
-
-
-

--- a/tests/access_control/test_cond2fa_non_member.py
+++ b/tests/access_control/test_cond2fa_non_member.py
@@ -22,7 +22,7 @@ class TestCond2faGroupMember:
 
     def test_a(self):
         """
-        Prompted for pwd only on diafine8
+        a. Prompted for pwd only on diafine8
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine8
@@ -34,7 +34,7 @@ class TestCond2faGroupMember:
 
     def test_b(self):
         """
-        No prompts on diafine8.
+        b. No prompts on diafine8.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6

--- a/tests/access_control/test_cond_access_group_member.py
+++ b/tests/access_control/test_cond_access_group_member.py
@@ -66,7 +66,7 @@ class TestCondAccessGroupMember:
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. No prompts on diafine9.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -83,10 +83,7 @@ class TestCondAccessGroupMember:
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd then 2FA on diafine9.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6

--- a/tests/access_control/test_cond_access_non_member.py
+++ b/tests/access_control/test_cond_access_non_member.py
@@ -22,7 +22,7 @@ class TestCondAccessNonMember:
 
     def test_a(self):
         """
-        Access error URL returned on diafine9.
+        a. Access error URL returned on diafine9.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine9
@@ -35,7 +35,7 @@ class TestCondAccessNonMember:
 
     def test_b(self):
         """
-        Access denied on diafine9. Access error URL returned.
+        b. Access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -72,9 +72,6 @@ class TestCondAccessNonMember:
 
     def test_d(self):
         """
-        d. Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfa.
-        Close browser.
         d. Access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
@@ -94,9 +91,6 @@ class TestCondAccessNonMember:
 
     def test_e(self):
         """
-        e. Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
-        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
-        Close browser.
         e. Prompted for pwd, then 2FA, then access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()

--- a/tests/access_control/test_cond_access_non_member.py
+++ b/tests/access_control/test_cond_access_non_member.py
@@ -3,12 +3,12 @@ from webdriver_recorder.browser import Chrome
 from tests.models import ServiceProviderInstance
 
 
-class TestCondAccessGroupMember:
+class TestCondAccessNonMember:
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid7):
+    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form, netid3):
         """
-        AC-3.1	Conditional access, tester is group member.
-        diafine9, sptest07
+        AC-3.2	Conditional access, tester is not group member.
+        diafine9, sptest03
         """
         self.utils = utils
         self.sp_url = sp_url
@@ -18,23 +18,24 @@ class TestCondAccessGroupMember:
         self.test_env = test_env
         self.two_fa_submit_form = two_fa_submit_form
         self.login_submit_form = login_submit_form
-        self.netid = netid7
+        self.netid = netid3
 
     def test_a(self):
         """
-        a. Prompted for pwd on diafine9.
+        Access error URL returned on diafine9.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine9
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.set_window_size(500, 1000)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_b(self):
         """
-        b. No prompts on diafine9.
+        Access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -42,14 +43,17 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+
         sp = ServiceProviderInstance.diafine9
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.set_window_size(500, 1000)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()
 
     def test_c(self):
         """
-        c. Prompted for pwd on diafine9.
+        c. Prompted for pwd, then access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -57,16 +61,21 @@ class TestCondAccessGroupMember:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+
         sp = ServiceProviderInstance.diafine9
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}force')
             self.login_submit_form(fresh_browser, self.netid, self.password)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.set_window_size(500, 1000)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_d(self):
         """
-        No prompts on diafine9.
+        d. Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
+        Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfa.
+        Close browser.
+        d. Access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -75,18 +84,20 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+
         sp = ServiceProviderInstance.diafine9
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.set_window_size(600, 1000)
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
             fresh_browser.close()
 
     def test_e(self):
         """
-        Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
+        e. Start 2FA session at https://diafine6.sandbox.iam.s.uw.edu/shibevalmfa.
         Use SSO to access https://diafine9.sandbox.iam.s.uw.edu/shibevalmfaforce.
         Close browser.
-        Prompted for pwd then 2FA on diafine9.
+        e. Prompted for pwd, then 2FA, then access denied on diafine9. Access error URL returned.
         """
         fresh_browser = Chrome()
         sp = ServiceProviderInstance.diafine6
@@ -95,9 +106,11 @@ class TestCondAccessGroupMember:
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+
         sp = ServiceProviderInstance.diafine9
         with self.utils.using_test_sp(sp):
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfaforce')
             self.login_submit_form(fresh_browser, self.netid, self.password)
             self.two_fa_submit_form(fresh_browser)
-            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.wait_for_tag('p', 'You are not authorized to access the application:')
+            fresh_browser.close()

--- a/tests/access_control/test_sp_opt_out.py
+++ b/tests/access_control/test_sp_opt_out.py
@@ -1,0 +1,56 @@
+import pytest
+from webdriver_recorder.browser import Chrome
+from tests.models import ServiceProviderInstance
+
+
+class TestSpOptOut:
+    @pytest.fixture(autouse=True)
+    def initialize(self, utils, secrets, sp_url, test_env, sp_domain, two_fa_submit_form, login_submit_form):
+        """
+        AC-6 SP opt-out	diafine12, sptest03, sptest04
+        """
+        self.utils = utils
+        self.sp_url = sp_url
+        self.sp_domain = sp_domain
+        self.password = secrets.test_accounts.password
+        self.passcode = secrets.test_accounts.duo_code
+        self.test_env = test_env
+        self.two_fa_submit_form = two_fa_submit_form
+        self.login_submit_form = login_submit_form
+
+    def test_a(self, netid3):
+        """
+        a. Prompted for pwd (SP opt-out trumps auto-2FA).
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine12
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
+            self.login_submit_form(fresh_browser, netid3, self.password)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
+
+    def test_b(self, netid4):
+        """
+        b. Sign in sptest04 using the Eval "Password authn" link (https://diafine12.sandbox.iam.s.uw.edu/shibeval).
+        b. Prompted for pwd (SP opt-out trumps user opt-in).
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine12
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
+            self.login_submit_form(fresh_browser, netid4, self.password)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+
+    def test_c(self, netid3):
+        """
+        c. Sign in sptest03 using the Eval "Token authn" link (https://diafine12.sandbox.iam.s.uw.edu/shibevalmfa).
+        c. Prompted for pwd, then 2FA (requested MFA authnContextClassRef trumps SP opt-out).
+        """
+        fresh_browser = Chrome()
+        sp = ServiceProviderInstance.diafine12
+        with self.utils.using_test_sp(sp):
+            fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}mfa')
+            self.login_submit_form(fresh_browser, netid3, self.password)
+            self.two_fa_submit_form(fresh_browser)
+            fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')

--- a/tests/access_control/test_sp_opt_out.py
+++ b/tests/access_control/test_sp_opt_out.py
@@ -32,7 +32,6 @@ class TestSpOptOut:
 
     def test_b(self, netid4):
         """
-        b. Sign in sptest04 using the Eval "Password authn" link (https://diafine12.sandbox.iam.s.uw.edu/shibeval).
         b. Prompted for pwd (SP opt-out trumps user opt-in).
         """
         fresh_browser = Chrome()
@@ -41,10 +40,10 @@ class TestSpOptOut:
             fresh_browser.get(f'{self.sp_url(sp)}/shib{self.test_env}')
             self.login_submit_form(fresh_browser, netid4, self.password)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()
 
     def test_c(self, netid3):
         """
-        c. Sign in sptest03 using the Eval "Token authn" link (https://diafine12.sandbox.iam.s.uw.edu/shibevalmfa).
         c. Prompted for pwd, then 2FA (requested MFA authnContextClassRef trumps SP opt-out).
         """
         fresh_browser = Chrome()
@@ -54,3 +53,4 @@ class TestSpOptOut:
             self.login_submit_form(fresh_browser, netid3, self.password)
             self.two_fa_submit_form(fresh_browser)
             fresh_browser.wait_for_tag('h2', f'{self.sp_domain(sp)} sign-in success!')
+            fresh_browser.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,11 @@ def netid() -> str:
 
 
 @pytest.fixture
+def netid2() -> str:
+    return AccountNetid.sptest02.value
+
+
+@pytest.fixture
 def netid3() -> str:
     return AccountNetid.sptest03.value
 
@@ -133,6 +138,11 @@ def netid3() -> str:
 @pytest.fixture
 def netid4() -> str:
     return AccountNetid.sptest04.value
+
+
+@pytest.fixture
+def netid5() -> str:
+    return AccountNetid.sptest05.value
 
 
 @pytest.fixture
@@ -149,17 +159,16 @@ def netid7() -> str:
 def netid8() -> str:
     return AccountNetid.sptest08.value
 
+
+@pytest.fixture
+def netid10() -> str:
+    return AccountNetid.sptest10.value
+
+
 @pytest.fixture
 def clean_browser(browser: Chrome) -> Chrome:
     browser.delete_all_cookies()
     return browser
-
-
-@pytest.fixture
-def my_fixture():
-    def _method(a, b):
-        return a*b
-    return _method
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,11 @@ def netid3() -> str:
 
 
 @pytest.fixture
+def netid4() -> str:
+    return AccountNetid.sptest04.value
+
+
+@pytest.fixture
 def netid6() -> str:
     return AccountNetid.sptest06.value
 

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -11,40 +11,6 @@ from tests.helpers import Locators
 from tests.models import ServiceProviderInstance, AccountNetid
 
 
-@pytest.fixture
-def netid() -> str:
-    return AccountNetid.sptest01.value
-
-
-@pytest.fixture
-def netid2() -> str:
-    return AccountNetid.sptest02.value
-
-
-@pytest.fixture
-def netid3() -> str:
-    return AccountNetid.sptest03.value
-
-
-@pytest.fixture
-def netid4() -> str:
-    return AccountNetid.sptest04.value
-
-
-@pytest.fixture
-def netid5() -> str:
-    return AccountNetid.sptest05.value
-
-
-@pytest.fixture
-def netid10() -> str:
-    return AccountNetid.sptest10.value
-
-
-def add_suffix(suffix: str, netid: str) -> str:
-    return f'{netid}{suffix}'
-
-
 def test_new_session_no_duo(utils, sp_url, sp_domain, secrets, netid, test_env):
     """
     2FA-1 New session, 2FA sign-in, user doesn't have a Duo account or a TAWS CRN.
@@ -329,12 +295,6 @@ def test_remember_me_cookie(utils, sp_url, sp_domain, secrets, netid3, test_env)
             fresh_browser.click(Locators.submit_button)
             fresh_browser.wait_for_tag('h2', f'{sp_domain(sp)} sign-in success!')
         fresh_browser.close()
-
-
-def test_forget_me_admin():
-    """
-    2FA-10 Forget me (admin) per Michael, this test is not yet ready to be automated.
-    """
 
 
 def test_forget_me_self_service(utils, sp_url, sp_domain, secrets, netid3, test_env):

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -70,7 +70,20 @@ def test_attributes(browser, netid, utils, sp_url, sp_domain, secrets, test_env)
         content_clean = content.get_attribute('innerHTML')
         attribute_data = [item.strip() for item in content_clean.split("<br>")]
 
+        # eduPersonScopedAffiliation is a unique case
+        wanted_key = 'eduPersonScopedAffiliation'
+        result = list(filter(lambda x: x.startswith(wanted_key), attribute_data))
+        found_values = result[0].split("= ", 1)[1].split(";")
+
         for key, value in attributes_to_test.items():
             # matches on exact string only. mail won't count as a match for uwEduEmail and uwEduEmail won't match mail
-            assert (f'{key} = {value}' in attribute_data)
+            if key != 'eduPersonScopedAffiliation':
+                assert (f'{key} = {value}' in attribute_data)
+            # eduPersonScopedAffiliation values may not be in the same order every time.
+            elif key == 'eduPersonScopedAffiliation':
+                assert len(found_values) == 4
+                assert 'employee@washington.edu' in found_values
+                assert 'student@washington.edu' in found_values
+                assert 'staff@washington.edu' in found_values
+                assert 'member@washington.edu' in found_values
         fresh_browser.close()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -72,18 +72,21 @@ def test_attributes(browser, netid, utils, sp_url, sp_domain, secrets, test_env)
 
         # eduPersonScopedAffiliation is a unique case
         wanted_key = 'eduPersonScopedAffiliation'
-        result = list(filter(lambda x: x.startswith(wanted_key), attribute_data))
-        found_values = result[0].split("= ", 1)[1].split(";")
+
+        result = next(filter(lambda x: x.startswith(wanted_key), attribute_data))
+        found_values = set(result.split("= ")[1].split(";"))
 
         for key, value in attributes_to_test.items():
-            # matches on exact string only. mail won't count as a match for uwEduEmail and uwEduEmail won't match mail
-            if key != 'eduPersonScopedAffiliation':
-                assert (f'{key} = {value}' in attribute_data)
-            # eduPersonScopedAffiliation values may not be in the same order every time.
-            elif key == 'eduPersonScopedAffiliation':
-                assert len(found_values) == 4
-                assert 'employee@washington.edu' in found_values
-                assert 'student@washington.edu' in found_values
-                assert 'staff@washington.edu' in found_values
-                assert 'member@washington.edu' in found_values
+            if key == wanted_key:
+                assert found_values == {
+                    'employee@washington.edu',
+                    'student@washington.edu',
+                    'staff@washington.edu',
+                    'member@washington.edu',
+                }, f'Unexpected attributes found in comparison with: {found_values}'
+            else:
+                # matches on exact string only. mail won't count as a match for uwEduEmail and uwEduEmail won't match
+                # mail
+                assert f'{key} = {value}' in attribute_data
+
         fresh_browser.close()


### PR DESCRIPTION
This does not cover :
Password sign-in tests: PWD-10 Blacklisted cookie (disuser case) - requires UWCA certificate and correct curl command
2FA sign-in tests: 2FA-10 Forget me (self-service) - requires UWCA certificate and correct curl command
NameID Release tests: NID-1 thru NID-5 (all) - this data is not available in `server-vars.aspx`

This does cover the remaining tests
[[AUTH-1490]](https://jira.cac.washington.edu/browse/AUTH-1490) Updates documentation
[[AUTH-1439]](https://jira.cac.washington.edu/browse/AUTH-1439) IdP Access Control tests
[[AUTH-1491]](https://jira.cac.washington.edu/browse/AUTH-1491) Update to `test_attributes.py`
Misc test cleanup (remove duplicate fixtures, clean docstring test descriptions...)
