### PR TITLE
[AUTH-1484] Support running via docker, including `/etc/hosts` support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+ARG SOURCE_TAG=latest
+ARG DI=dependency-image
+FROM ghcr.io/uwit-iam/poetry:${SOURCE_TAG} AS dependency-image
+WORKDIR /uw-idp-tests
+COPY poetry.lock pyproject.toml ./
+ENV ALLOW_HOSTS_MODIFICATION "1"
+RUN apt-get -y install curl jq dnsutils && poetry install
+
+FROM $DI AS uw-idp-web-tests
+COPY settings.yaml scripts/set-idp-host.sh scripts/wait-for-selenium.sh ./
+COPY tests/ ./tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Contains a test suite for UW's identity provider, using mock Shibboleth service 
 
 Detailed information can be found in the [docs](docs) directory.
 
+## Quickstart
+
+- Follow the [bare minimum setup instructions](#bare-minimum)
+- Run `./scripts/run-tests.sh`
+
 # Dev Environment Setup
+
+## Bare Minimum 
 
 **If you are new to maintaining or running these tests, you must start here!**
 
@@ -12,9 +19,13 @@ Detailed information can be found in the [docs](docs) directory.
 [docs/cloud-integration](docs/cloud-integration.md#CreatingAServiceAccount) and ensure you are 
 exporting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
-## For running locally (via python virtualenv)
+2\. [Install docker](https://docs.docker.com/get-docker/) on your machine, 
+    and make sure the docker daemon is running.
 
-If you want IDE integration and easier debugging, do this!
+## For running locally (via poetry)
+
+Only required if you need more than the docker functionality. 
+For instance, if you want IDE integration and easier debugging, do this!
 
 1\. [Install pyenv](https://github.com/pyenv/pyenv#installation) (if you haven't already)
 
@@ -71,6 +82,38 @@ for more information on configuring your test environment.
 
 Please keep in mind that the default options will take a few minutes to start due to cold start delays for our
 [test service providers](docs/test-service-providers.md).
+
+
+## Via docker
+
+```
+./scripts/run-tests.sh
+```
+
+You can pass additional arguments to pytest using the 
+special `--` and `+-` arguments, example:
+
+`--` will replace all default environment variables; `+-` will append to default 
+variables. (Use this if you want nice log output).
+
+**Example using `--`:**
+
+```
+./scripts/run-tests.sh -- --maxfail 1 tests/test_2fa_duo.py
+# ...
+# will output something like:
+ Running pytest with args: --maxfail 1 tests/test_2fa_duo.py
+```
+
+**Example using `+-`:**
+```
+./scripts/run-tests.sh +- --settings-profile in_development tests/test_attributes.py
+# ...
+# will output something like: 
+Running pytest with args: -o log_cli=true -o log_cli_level=info --settings-profile in_development tests/test_attributes.py
+```
+
+For more information, run `./scripts/run-tests.sh --help`
 
 
 ## Via virtualenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+# To execute this docker-compose yml file use `docker-compose -f docker-compose-v3.yml up`
+# Add the `-d` flag at the end for detached execution
+# To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-v3.yml down`
+version: "3"
+services:
+  # This is the testing image built from the Dockerfile in this repository.
+  # This requires a `CREDENTIAL_DIRNAME` environment variable be set when you
+  # run the composition, if you run it directly. The value of that variable should
+  # be the location on the host's (i.e., your) machine that houses the
+  # file name built into the Docker image. If the full path to your credential key is
+  # "/etc/secrets/uwit-mci-iam-key.json," then the value here would be "/etc/secrets"
+  # This directory will be mounted onto the image, and the image will access the
+  # built-in filename. This prevents credentials from hanging out in images when
+  # they're not running.
+  #
+  # You can optionally configure the test configuration by setting a
+  # PYTEST_ARGS environment variable. This will override all arguments to python
+  # except for the "--report-dir," which is mounted to the host's working directory.
+  # For more information on useful arguments, see docs/pytest.md.
+  test-runner:
+    image: ghcr.io/uwit-iam/idp-web-tests:build
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /secrets/${CREDENTIAL_FILE_NAME}
+      AWS_DEFAULT_REGION: us-west-2
+      TZ: America/Los_Angeles
+      PYTEST_ARGS: ${PYTEST_ARGS}
+      UPLOAD_FILENAME: ${TEST_ARTIFACT_OBJECT_NAME}
+      REPORT_DIR: /tmp/webdriver-report
+      TARGET_IDP_HOST: ${TARGET_IDP_HOST}
+    depends_on:
+      - chrome
+      - selenium-hub
+    volumes:
+      - ${CREDENTIAL_MOUNT_POINT}:/secrets:ro
+      - ${REPORT_MOUNT_POINT}:/tmp/webdriver-report
+    command: >
+      bash -c "./set-idp-host.sh -t ${TARGET_IDP_HOST} &&
+      mkdir -pv ${REPORT_DIR} && rm -vf ${REPORT_DIR}/* &&
+      ./wait-for-selenium.sh &&
+      echo Running pytest with args: ${PYTEST_ARGS} &&
+      pytest ${PYTEST_ARGS}
+      "
+
+  # Originally sourced from vendor-provided documentation
+  # at: https://github.com/SeleniumHQ/docker-selenium/tree/selenium-3
+  selenium-hub:
+    image: selenium/hub:3.141.59-20210607
+    container_name: selenium-hub
+    ports:
+      - "4444:4444"
+    logging:
+      driver: 'none'
+
+  chrome:
+    image: selenium/node-chrome:3.141.59-20210607
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+    logging:
+      driver: 'none'

--- a/docs/settings-and-options.md
+++ b/docs/settings-and-options.md
@@ -1,5 +1,17 @@
 # Test Settings and Options
 
+For a list of command-line options available for these tests, use 
+`poetry run pytest --help` (or `./scripts/run-tests.sh -- --help`). Look for the 
+section titled `idp_tests`.
+
+For a list of options available for configuration the dockerized tests, use
+`./scripts/run-tests.sh --help`.
+
+See [settings.yml](../settings.yaml) for the canned settings profiles and default
+options.
+
+---
+
 This test suite aims to be highly configurable where needed. Because there are lots of moving parts here, all 
 settings can be loaded from a `.yaml` file. 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -598,7 +598,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uw-webdriver-recorder"
-version = "4.0.0"
+version = "4.0.1a1"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 category = "main"
 optional = false
@@ -624,7 +624,7 @@ multimethod = ">=1.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "af6c7a3971a337e8fd8ebe709e5f7a719c0ede37f233e4fa7d78e0e6ab96be72"
+content-hash = "8d53405b7ab0c314505a2439491f8ac7ea86c1eae3cdfc412b97b54fbe25e948"
 
 [metadata.files]
 appdirs = [
@@ -1039,8 +1039,8 @@ urllib3 = [
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]
 uw-webdriver-recorder = [
-    {file = "uw-webdriver-recorder-4.0.0.tar.gz", hash = "sha256:6ee22bba5dc36db3a5894da2c2c5459c764390bb23c058d2c6d13d718ae39f99"},
-    {file = "uw_webdriver_recorder-4.0.0-py3-none-any.whl", hash = "sha256:1ab3d0bb9033b8ec6509c4da1a8495750c0298433370e25246d8d9249a799d1b"},
+    {file = "uw-webdriver-recorder-4.0.1a1.tar.gz", hash = "sha256:e6eceea552fe561755f39e83d52efb627ce2ebb5be547e4ae7244f4f8865dd71"},
+    {file = "uw_webdriver_recorder-4.0.1a1-py3-none-any.whl", hash = "sha256:cc5d6ce6098a3fcd0291ad11bdc720c6c1830990a58c95d989f219e8c1505e6d"},
 ]
 waiter = [
     {file = "waiter-1.2-py3-none-any.whl", hash = "sha256:7cd4ccec9a7aa632a2a11eebc219fa925221c7150edff31a7030a5198ba4265e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ pydantic = "^1.8.2"
 pytest = "^6.2.4"
 PyYAML = "^5.4.1"
 typing-extensions = "^3.10.0"
-uw-webdriver-recorder = ">=4.0.0,<4.1.0"
+# Pinned until https://github.com/UWIT-IAM/webdriver-recorder/pull/25
+# is merged and released.
+uw-webdriver-recorder = "4.0.1-alpha.1" # ">=4.0.0,<4.1.0"
 waiter = "^1.2"
 
 [tool.poetry.dev-dependencies]

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+function print_help {
+   cat <<EOF
+   Use: run-tests.sh [--debug --help]
+   Options:
+   --help/-h      Show this message and exit
+   --debug/-g     Show commands as they are executing
+   --report-id    Set the report artifact name (not yet used)
+   --no-build     Do not rebuild the image before running
+   --strict-host  Provide this with an arugment (e.g., "idp11") to route all
+                  idp traffic to a single host.
+   --source-tag   You may define a different image other than `latest`
+                  for the base UWIT-IAM/poetry image
+   -- [...]       All input after `--` will be sent to pytest as CLI arguments.
+   +- [...]       All input after `+-` will be appended to default pytest CLI arguments.
+EOF
+}
+
+export PYTEST_ARGS="${PYTEST_ARGS:-"-o log_cli=true -o log_cli_level=info"}"
+test -z "$PYTEST_EXT_ARGS" || PYTEST_ARGS="${PYTEST_ARGS} ${PYTEST_EXT_ARGS}"
+
+function parse_args() {
+  while (( $# ))
+  do
+    case $1 in
+      --help|-h)
+        print_help
+        exit 0
+        ;;
+      --report-id)
+        shift
+        TEST_ARTIFACT_OBJECT_NAME="$1"
+        ;;
+      --report-dir)
+        shift
+        REPORT_MOUNT_POINT=$1
+        ;;
+      --no-build)
+        NO_BUILD=1
+        ;;
+      --source-tag)
+        shift
+        export SOURCE_TAG=$1
+        ;;
+      --strict-host)
+        shift
+        STRICT_HOST=$1
+        ;;
+      --)
+        shift
+        export PYTEST_ARGS="$@"
+        return
+        ;;
+      +-)
+        shift
+        PYTEST_ARGS+=" $@"
+        return
+        ;;
+      *)
+        echo "Invalid Option: $1"
+        print_help
+        return 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_args "$@" || exit 1
+
+if [[ -z "${NO_BUILD}" ]]
+then
+  set -e
+  docker build --build-arg SOURCE_TAG -t ghcr.io/uwit-iam/idp-web-tests:build .
+  set +e
+fi
+
+function validate_args() {
+  FAILED=
+  test -n "${GOOGLE_APPLICATION_CREDENTIALS}" || FAILED=1
+  if [[ -n "$FAILED" ]]
+  then
+    echo "Cannot create test environment. You must provide the
+    GOOGLE_APPLICATION_CREDENTIALS environment variable."
+    exit 1
+  fi
+
+}
+
+
+function sanitize_pytest_args() {
+  if ! [[ "${PYTEST_ARGS}" =~ '--settings-profile' ]]
+  then
+    PYTEST_ARGS="$PYTEST_ARGS --settings-profile docker_compose"
+  fi
+}
+
+validate_args
+sanitize_pytest_args
+export TARGET_IDP_HOST="${STRICT_HOST}"
+export CREDENTIAL_MOUNT_POINT="$(dirname $GOOGLE_APPLICATION_CREDENTIALS)"
+export CREDENTIAL_FILE_NAME="$(basename $GOOGLE_APPLICATION_CREDENTIALS)"
+export PYTEST_ARGS="${PYTEST_ARGS}"
+export TEST_ARTIFACT_OBJECT_NAME="${REPORT_ID}"
+export REPORT_MOUNT_POINT=${REPORT_DIR:-./webdriver-report}
+export REPORT_DIR="${REPORT_DIR:-./webdriver-report}"
+export COMPOSE_ARGS="${COMPOSE_ARGS:-up --exit-code-from test-runner}"
+docker-compose -f docker-compose.selenium.yml ${COMPOSE_ARGS}

--- a/scripts/set-idp-host.sh
+++ b/scripts/set-idp-host.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+function print_help {
+   cat <<EOF
+   Use: set-idp-host.sh [--debug --help]
+   Options:
+   --help/-h      Show this message and exit
+   --debug/-g     Show commands as they are executing
+   --host/-t      The target host (ip address will be looked up) in the
+                  form of idpXX (e.g., idp14).
+   --env/-e       'prod' or 'eval'; the idp endpoint to route to
+EOF
+}
+
+HOST_IP=
+TARGET_ENV=prod
+
+
+function get_host_ip() {
+  local host="$1"
+  if [[ -z "$host" ]]
+  then
+    return 0
+  fi
+  if [[ "$host" =~ idp[0-9]+ ]]
+  then
+    host="$host.s.uw.edu"
+  else
+    echo "--host/-t argument must be in the form of idpXX (e.g., "idp14");"
+    echo "  you entered '$host'"
+    return 1
+  fi
+  echo "$(dig +short $host)"
+}
+
+
+function configure_environment() {
+  local idp_domain_prefix=
+  if [[ "$TARGET_ENV" == 'eval' ]]
+  then
+    idp_domain_prefix='-eval'
+  fi
+  IDP_DOMAIN="idp${idp_domain_prefix}.u.washington.edu"
+  HOSTS_LINE="$HOST_IP $IDP_DOMAIN"
+}
+
+
+while (( $# ))
+do
+  case $1 in
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --host|-t)
+      shift
+      if [[ -n "$1" ]]
+      then
+        HOST_IP="$(get_host_ip "$1")"
+        if [[ "$?" -gt "0" ]]
+        then
+          echo "$HOST_IP"
+          exit 1
+        elif [[ -z "$HOST_IP" ]]
+        then
+          echo "No IP address found for $1"
+          exit 1
+        else
+          echo "Found IP $HOST_IP for host $1"
+        fi
+      fi
+      ;;
+    --env|-e)
+      shift
+      TARGET_ENV=$1
+      ;;
+    *)
+      echo "Invalid Option: $1"
+      print_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$HOST_IP" ]]
+then
+  echo "No host provided; nothing to do!"
+  exit 0
+fi
+
+
+
+configure_environment
+
+if [[ -z "${ALLOW_HOSTS_MODIFICATION}" ]]
+then
+  echo "This script should only be run inside a docker container."
+  echo "Use the following command to amend your personal /etc/hosts file:"
+  echo
+  echo "    sudo echo \"$HOSTS_LINE\" >> /etc/hosts"
+  echo
+  echo "You are responsible for cleaning up your own work station!"
+else
+  echo "Routing all traffic bound for $IDP_DOMAIN to IP $HOST_IP"
+  echo "$HOSTS_LINE" >> /etc/hosts
+fi

--- a/scripts/wait-for-selenium.sh
+++ b/scripts/wait-for-selenium.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Waiting for selenium to be ready . . ."
+
+while [[ "$ready" != 'true' ]]
+do
+  status=$(curl -sq http://selenium-hub:4444/wd/hub/status)
+  ready=$(echo $status | jq -s .[0].value.ready)
+  sleep 1
+done

--- a/settings.yaml
+++ b/settings.yaml
@@ -12,32 +12,27 @@ base: &base
   aws_hosted_zone:
     name: sandbox.iam.s.uw.edu
     id: ZTMZX8EZCH1AH
-    # This is not corroborated against any given endpoint; this is the AWS default, and is used here for a polling task
-    # Override this to extend the wait time for propagation if necessary; will not change the
-    # actual host record.
+    # This is not corroborated against any given endpoint;
+    # this is the AWS default, and is used here for a polling task
+    # Override this to extend the wait time for propagation if necessary;
+    # will not change the actual host record.
     ttl: 300
   secret_manager:
     project: uwit-mci-iam
     secret_name: idp-web-test-config
     version: latest
   test_options: &base_test_options
-    # These are toggleable options. You can override them in a yaml section for reuse, or you can override them
-    # from the command line by "dasherizing" the option name.
-    # e.g., skip_test_service_provider_start can be
-    #       overridden by doing `pytest --skip-test-service-provider-start`
     skip_test_service_provider_start: False
     skip_test_service_provider_stop: False
-    hosts_file: /etc/hosts
     use_local_secrets: false
-    local_secrets_filename: secrets.json
     report_title: UW IdP Web Tests
 
 
 docker_compose:
   <<: *base
-  test_options:
+  test_options: &compose_options
     <<: *base_test_options
-    selenium_server: selenium:4444
+    selenium_server: selenium-hub:4444
 
 
 # Run with --settings-profile in_development to
@@ -46,6 +41,7 @@ docker_compose:
 in_development:
   <<: *base
   test_options:
+    <<: *compose_options
     skip_test_service_provider_start: True
     skip_test_service_provider_stop: True
     env: eval

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import copy
 import logging
 from typing import Callable, NoReturn, Optional
 
-import inflection
 import pytest
 from webdriver_recorder.browser import BrowserRecorder, Chrome, Remote
 
@@ -12,44 +11,38 @@ from tests.secret_manager import SecretManager
 
 
 def pytest_addoption(parser):
-    parser.addoption('--settings-file', default='settings.yaml',
+    group = parser.getgroup('idp_tests')
+    group.addoption('--settings-file', default='settings.yaml',
                      help="Use this if you want to provide a settings YAML file yourself.")
-    parser.addoption('--settings-profile', default='base',
+    group.addoption('--settings-profile', default='base',
                      help="Use this if you want to use settings from a specific root node of the settings file.")
-    parser.addoption('--reuse-chromedriver', default=4444,
-                     help="Where possible, the test suite will try to reuse a single chromedriver connection."
-                          "If you can't or don't want to use the default port for this, you may set a different port "
-                          "with this option.")
-    parser.addoption("--env", action="store", default="prod", help="Use this is you want to set the test environment "
-                                                                   "to eval or prod. Default environment is prod. "
-                                                                   "Usage: --env=eval or --env=prod")
-    for field, f_config in TestOptions.__fields__.items():
-        option_name = f'--{inflection.dasherize(field)}'
-        help_text = f_config.field_info.description
-        if not f_config.field_info.extra.get('add_cli_arg', True):
-            continue
-        option_default = f_config.default
-        option_type = f_config.type_
-        kwargs = dict(default=option_default, help=help_text)
-        if option_type is bool:
-            action = 'store_false' if option_default is True else 'store_true'
-            kwargs['action'] = action
 
-        parser.addoption(option_name, **kwargs)
+    TestOptions.apply_to_parser(group)
 
 
 @pytest.fixture(scope='session')
-def chrome_options(chrome_options):
-    chrome_options.add_argument('disable-extensions')
-    chrome_options.add_argument('disable-crash-reporter')
-    return chrome_options
+def selenium_server(settings) -> str:
+    return settings.test_options.selenium_server
+
+
+@pytest.fixture
+def browser(fresh_browser):
+    """
+    Override the default browser fixture so that a `session_browser`
+    instance is NOT created. We will only use fresh browsers in
+    this very edge-case-y suite.
+    """
+    return fresh_browser
 
 
 @pytest.fixture(scope='session')
 def settings(request) -> WebTestSettings:
     filename = request.config.getoption('--settings-file')
     settings_env = request.config.getoption('--settings-profile')
-    return load_settings(filename, settings_env, option_overrides=TestOptions.parse_overrides(request.config))
+    test_options = TestOptions.parse_overrides(request.config)
+    settings = load_settings(filename, settings_env, option_overrides=test_options)
+    logging.debug(f'Derived settings: {settings.dict()}')
+    return settings
 
 
 @pytest.fixture(scope='session')
@@ -121,11 +114,13 @@ def secrets(secret_manager) -> TestSecrets:
 
 
 @pytest.fixture(scope='session')
-def test_env(request):
+def test_env(settings):
     """
     Determines which environment the tests are run against, prod or eval. Prod is the default.
     """
-    return request.config.getoption("--env")
+    env = settings.test_options.env.value
+    logging.info(f"Testing against {env} idp stack")
+    return env
 
 
 @pytest.fixture
@@ -258,17 +253,17 @@ def log_in_netid(secrets: TestSecrets, sp_domain) -> Callable[..., NoReturn]:
 
 
 @pytest.fixture(scope='session')
-def get_fresh_browser(selenium_server, chrome_options, request) -> Callable[..., BrowserRecorder]:
+def get_fresh_browser(selenium_server, chrome_options) -> Callable[..., BrowserRecorder]:
     """
     This is a fixture function that creates a fresh browser instance
     based on the current environment configuration.
 
-        def test_the_thing(get_fresh_browser: Callable[None, BrowserRecorder]):
-            browser = get_fresh_browser()
+    Before you use this fixture directly, make sure the `browser` fixture
+    doesn't already do what you need.
 
-    You manage the scope of this browser; you should always make sure to
-    wrap the browser use in a try/finally block to call `quit()` on
-    the browser instance in all cases.
+    If you call this function directly, you manage the scope of this browser
+    instance; you must make sure to wrap the browser use in a try/finally
+    block to call `quit()` on the browser instance in all cases.
 
     Note that only the function is session-scoped (so that all scopes can use it);
     the instance created by the function is self-contained and will share the scope of
@@ -285,8 +280,8 @@ def get_fresh_browser(selenium_server, chrome_options, request) -> Callable[...,
         args['command_executor'] = f'http://{selenium_server}/wd/hub'
     else:
         browser_cls = Chrome
-        # Reuse a single local instance for the duration of the tests.
-        args['port'] = request.config.getoption('--reuse-chromedriver')
+        options.add_experimental_option('detach', True)
+        args['port'] = settings.test_options.reuse_chromedriver
 
     return lambda: browser_cls(**args)
 

--- a/tests/test_password_sign_on.py
+++ b/tests/test_password_sign_on.py
@@ -162,9 +162,7 @@ def test_new_session_sign_on_domain_credential(
     """
     PWD-7 New session, sign on with @domain credential format
     """
-    fresh_browser = Chrome()
     login = login_transform(netid)
-    password = secrets.test_accounts.password.get_secret_value()
     sp = ServiceProviderInstance.diafine6
     with utils.using_test_sp(sp):
         fresh_browser.get(sp_shib_url(sp))


### PR DESCRIPTION
- Tests can now be run via docker: `./scripts/run-tests.sh`
- When running via docker, you may supply the `--strict-host` to restrict all IDP traffic to a single host within the docker image: `./scripts/run-tests.sh --strict-host idp11`

More info can be found int he docs!