### PR TITLE
[AUTH-1503] account for more unordered values in the IdP tests

### DIFF
--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -59,7 +59,7 @@ def test_attributes(browser, netid, utils, sp_shib_url, sp_domain, test_env, log
     }
 
     undefined_order_keys = {  # These keys multiple values in an undefined order
-        'eduPersonAffiliation', 'eduPersonScopedAffiliation'
+        'eduPersonAffiliation', 'eduPersonEntitlement', 'eduPersonScopedAffiliation', 'isMemberOf'
     }
 
     def _parse_line(line):


### PR DESCRIPTION
Two more attributes were discovered to not have a guaranteed order.
Closes [Auth-1503](https://jira.cac.washington.edu/browse/AUTH-1503)