### PR TITLE
Add uwca options to TestOptions

### DIFF
--- a/.github/scripts/configure-workflow.sh
+++ b/.github/scripts/configure-workflow.sh
@@ -57,6 +57,19 @@ function get-workflow-snapshot-artifact() {
   echo "$payload"
 }
 
+function install-uwca-cert() {
+   if [[ -n "${UWCA_CERT}" ]]
+   then
+       echo "${UWCA_CERT}" | base64 -d > /tmp/uwca.crt
+       echo "Installed UWCA certificate"
+   fi
+   if [[ -n "${UWCA_KEY}" ]]
+   then
+       echo "${UWCA_KEY}" | base64 -d > /tmp/uwca.key
+       echo "Installed UWCA certificate key"
+   fi
+}
+
 function get-run-tests-args() {
   # Make sure the mount point is properly formatted for docker-compose;
   # if it's relative to the current directory, we must add `./`
@@ -75,6 +88,14 @@ function get-run-tests-args() {
   then
     payload+=" +- ${INPUT_PYTEST_ARGS}"
   fi
+  if [[ -n "${UWCA_CERT}" ]]
+  then
+    payload+=" --uwca-cert-filename /tmp/uwca.crt"
+  fi
+  if [[ -n "${UWCA_KEY}" ]]
+  then
+    payload+=" --uwca-key-filename /tmp/uwca.key"
+  fi
   echo "$payload"
 }
 
@@ -83,6 +104,7 @@ function configure-workflow() {
   local actor="$GITHUB_ACTOR"
   local artifact_object_path=$(get-report-output-path $event_name)
   INPUT_TARGET_IDP_ENV="${INPUT_TARGET_IDP_ENV:-eval}"
+  install-uwca-cert
   set-output report-object-path "$artifact_object_path"
   set-output report-url "$ARTIFACT_DOMAIN/$artifact_object_path/index.html"
   set-output short-sha "$(get-short-sha)"

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -89,6 +89,8 @@ jobs:
           INPUT_REASON: ${{ github.event.inputs.reason }}
           INPUT_SLACK_CHANNEL: ${{ github.event.inputs.slack-channel }}
           INPUT_PYTEST_ARGS: ${{ github.event.inputs.pytest-args }}
+          UWCA_CERT: ${{ secrets.UWCA_CERT }}
+          UWCA_KEY: ${{ secrets.UWCA_KEY }}
         run: |
           source ./.github/scripts/configure-workflow.sh
           configure-workflow

--- a/tests/models.py
+++ b/tests/models.py
@@ -127,6 +127,9 @@ class TestOptions(BaseSettings):
         description='If provided will use a Remote instance connection to the server.'
     )
     env: TestEnvironment = TestEnvironment.prod.value
+    uwca_cert_filename: Optional[str] = None
+    uwca_key_filename: Optional[str] = None
+    
     reuse_chromedriver: int = 4444
 
     @classmethod


### PR DESCRIPTION
## Change description

- Supports setting `--uwca-cert-filename` and `--uwca-key-filename` from the command line.
- Updates Actions workflow to use base64-encoded `UWCA_CERT` and `UWCA_KEY` secrets

---

## Next Steps

In order for this to be useful:

1. Secure a certificate that can be used for these tests (not a personal. washington.cac certificate); @jdiverp can help with that and authorizing it for the test use cases
2. Base64-encode the certificate and the key used to generate it (`cat <filename> | base64`); and [add the values as repository secrets](https://github.com/UWIT-IAM/uw-idp-web-tests/settings/secrets/actions/new). The secrets should be named `UWCA_CERT` and `UWCA_KEY`, respectively
3. The tests must be set up to use the values from the `settings` fixture. Example:

```
@pytest.mark.uwca_required
def test_a_thing(settings):
    cert = (settings.test_options.uwca_cert_filename, settings.test_options.uwca_key_filename)
    url = ...
    data = { ... }
    requests.get(url, cert=cert, data=data)
```

4. Please `@pytest.mark.uwca_required` any tests that require this, so that people who do not have certificates configured for that access can still run the tests, skipping those that cannot succeed (e.g., `pytest -k 'not uwca_required'`).

I have given you (@goulter) maintainer access to the repository so that you can set these secrets; JP can do this also as an org administrator.