### PR TITLE
Fix two issues in the test automation

### DIFF
--- a/.github/scripts/configure-workflow.sh
+++ b/.github/scripts/configure-workflow.sh
@@ -70,6 +70,19 @@ function install-uwca-cert() {
    fi
 }
 
+function configure-pytest-args() {
+  local payload="${INPUT_PYTEST_ARGS}"
+  if [[ -n "${UWCA_CERT}" ]]
+  then
+    payload+=" --uwca-cert-filename /tmp/uwca.crt"
+  fi
+  if [[ -n "${UWCA_KEY}" ]]
+  then
+    payload+=" --uwca-key-filename /tmp/uwca.key"
+  fi
+  echo "${payload}"
+}
+
 function get-run-tests-args() {
   # Make sure the mount point is properly formatted for docker-compose;
   # if it's relative to the current directory, we must add `./`
@@ -84,17 +97,11 @@ function get-run-tests-args() {
   then
     payload+=" --strict-host ${INPUT_TARGET_IDP_HOST}"
   fi
-  if [[ -n "${INPUT_PYTEST_ARGS}" ]]
+
+  local pytest_args="$(configure-pytest-args)"
+  if [[ -n "$pytest_args" ]]
   then
-    payload+=" +- ${INPUT_PYTEST_ARGS}"
-  fi
-  if [[ -n "${UWCA_CERT}" ]]
-  then
-    payload+=" --uwca-cert-filename /tmp/uwca.crt"
-  fi
-  if [[ -n "${UWCA_KEY}" ]]
-  then
-    payload+=" --uwca-key-filename /tmp/uwca.key"
+    payload+=" +- ${pytest_args}"
   fi
   echo "$payload"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
   # Originally sourced from vendor-provided documentation
   # at: https://github.com/SeleniumHQ/docker-selenium/tree/selenium-3
   selenium-hub:
-    image: selenium/hub:3.141.59-20210607
+    image: selenium/hub:3.141.59
     container_name: selenium-hub
     ports:
       - "4444:4444"
@@ -50,7 +50,7 @@ services:
       driver: 'none'
 
   chrome:
-    image: selenium/node-chrome:3.141.59-20210607
+    image: selenium/node-chrome:3.141.59
     volumes:
       - /dev/shm:/dev/shm
     depends_on:


### PR DESCRIPTION
- Pin selenium docker dependencies to an updateable pin (3.141.59) instead of a patch-level pin.
- Fix issue where uwca certificate arguments would be passed to the wrong script if no custom pytest args were set.

Tested by invoking the workflow three different ways: 

- [A manual trigger from the Actions UI](https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/1533030718) (included custom pytest arguments and only ran the 2fa tests)
- [An automated trigger from a pull request](https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/1533021342)
- [A push to the special "run-uw-idp-web-tests" branch](https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/1532990743)