### PR TITLE
[AUTH-1562] Add a tool to continuously generate login/logout requests to the idp

### DIFF
--- a/.github/workflows/idp-login-request-generator.yml
+++ b/.github/workflows/idp-login-request-generator.yml
@@ -1,3 +1,4 @@
+name: Generate Continuous IdP Login Requests
 on:
   workflow_dispatch:
     inputs:
@@ -34,6 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
       - env:
           load_balancer: ${{ github.event.inputs.load-balancer-ip }}
           num_loops: ${{ github.event.inputs.num-login-attempts }}
@@ -45,14 +52,8 @@ jobs:
         run: |
           ip_addr=$(dig ANY +short @resolver2.opendns.com myip.opendns.com)
           echo "::notice::Test runner ${{ matrix.runner-id }} IP address is ${ip_addr}"
-          run_tests_args="--with-override workflow --env ${idp_env}"
-          run_tests_args+=$(
-            test -z '${{ env.load_balancer }}' \
-            || echo ' --strict-ip ${{ env.load_balancer }}'
-          )
-          ./scripts/run-tests.sh ${run_tests_args} \
-            +- --skip-test-service-provider-start \
-            --skip-test-service-provider-stop \
-            --lb-num-loops ${num_loops} \
-            --lb-sleep-time ${sleep_time} \
-            tests/test_load_balancer.py
+          ./scripts/run-idp-login-request-generator.sh -n ${num_loops} -z ${sleep_time} -ip ${load_balancer}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test Runner ${{ matrix.runner-id }} webdriver-report
+          path: webdriver-report/index.html

--- a/docs/testing-sustained-requests.md
+++ b/docs/testing-sustained-requests.md
@@ -1,0 +1,38 @@
+# Generating Sustained Requests
+
+You can also generate login attempts from many different clients using
+Github Actions. This simply logs in to the UW Directory using the prod IDP.
+You may provide a specific IdP to route traffic through.
+
+While you _can_ run this from a bash terminal 
+(`./scripts/run-login-request-generator.sh`), this will only generate
+requests from a single IP address. 
+
+## Running from Github Actions
+
+To generate requests from multiple IP addresses, you can use the 
+[IdP Login Request Generator Workflow](https://github.com/UWIT-IAM/uw-idp-web-tests/actions/workflows/idp-login-request-generator.yml).
+
+Click the "Run Workflow" button. You will be presented with a form to configure
+the number of login attempts per host, and the wait time between login attempts.
+
+The number of hosts is fixed, but can be changed by updating the workflow in a
+separate branch, then selecting that branch on the form. (Otherwise, you should
+ always run this with the default branch selected).
+
+The IP addresses for the test runners will be available in the action run summary, 
+and the webdriver-report screenshots will also be included as artifacts in the same 
+summary.
+
+## Running from the CLI
+
+To run this locally using docker compose, you can just execute the
+bash helper script:
+
+```
+./scripts/run-idp-login-request-generator.sh
+```
+
+Use the `--help` flag for a menu of options that can be provided.
+
+Just remember that this will only generate requests from _your_ host.

--- a/scripts/run-idp-login-request-generator.sh
+++ b/scripts/run-idp-login-request-generator.sh
@@ -1,0 +1,71 @@
+function print_help {
+   cat <<EOF
+   Use: run-idp-testing-tool.sh [--debug --help]
+   Options:
+   -n, --num-login-attempts The number of login/logout cycles to attempt
+   -z, --login-attempt-wait-time-secs   How long to wait between each login attempt
+   -ip, --idp-ip   (Optional) A strict IP to send all idp requests through.
+   -b, --build     If used, will build a new image to run the test
+   -h, --help      Show this message and exit
+   -g, --debug     Show commands as they are executing
+EOF
+}
+
+num_login_attempts=1
+sleep_time=5
+image=ghcr.io/uwit-iam/idp-web-tests:lb-test
+
+function parse_args {
+  while (( $# ))
+  do
+    case $1 in
+      --help|-h)
+        print_help
+        exit 0
+        ;;
+      -n|--num-login-attempts)
+        shift
+        num_login_attempts="$1"
+        ;;
+      -z|--login-attempt-wait-time-secs)
+        shift
+        sleep_time="$1"
+        ;;
+      -ip|--idp-ip)
+        shift
+        idp_ip="$1"
+        ;;
+      -b|--build)
+        force_build=1
+        ;;
+      --debug|-g)
+        DEBUG=1
+        ;;
+      *)
+        echo "Invalid Option: $1"
+        print_help
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+test -z "${DEBUG}" || set -x
+export DEBUG="${DEBUG}"
+}
+
+parse_args "$@"
+
+if [[ -z "${force_build}" ]]
+then
+  docker pull ${image}
+  docker tag ${image} ghcr.io/uwit-iam/idp-web-tests:build
+fi
+
+./scripts/run-tests.sh \
+  --env prod \
+  $(test -z "${idp_ip}" || echo "--strict-ip ${idp_ip}") \
+  $(test -n "${force_build}" || echo "--no-build") \
+  +- --skip-test-service-provider-start --skip-test-service-provider-stop \
+  --lb-num-loops ${num_login_attempts} --lb-sleep-time ${sleep_time} \
+  tests/test_generate_requests.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,8 @@ def pytest_addoption(parser):
                     help="If set to a number greater than 0, "
                          "the test_generate_requests.py test will make IdP requests the given number of times.")
     group.addoption('--lb-sleep-time', default=60,
-                    help="The number of seconds to sleep between login attempts when running the 'load-balancer' "
-                         "mark.")
+                    help="The number of seconds to sleep between login attempts when running login request "
+                         "generator.")
 
     TestOptions.apply_to_parser(group)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,12 @@ def pytest_addoption(parser):
                      help="Use this if you want to provide a settings YAML file yourself.")
     group.addoption('--settings-profile', default='base',
                      help="Use this if you want to use settings from a specific root node of the settings file.")
+    group.addoption('--lb-num-loops', default=0,
+                    help="If set to a number greater than 0, "
+                         "the test_generate_requests.py test will make IdP requests the given number of times.")
+    group.addoption('--lb-sleep-time', default=60,
+                    help="The number of seconds to sleep between login attempts when running the 'load-balancer' "
+                         "mark.")
 
     TestOptions.apply_to_parser(group)
 

--- a/tests/test_generate_requests.py
+++ b/tests/test_generate_requests.py
@@ -1,0 +1,49 @@
+import time
+
+from webdriver_recorder.browser import Locator, SearchMethod
+
+
+def test_make_continuous_requests(request, browser, netid, secrets):
+    """
+    By default this test will exit successfully without doing anything.
+    Test runners must set "--lb-num-loops" in order for this test to
+    do anything.
+    """
+    num_loops = int(request.config.getoption('lb_num_loops', default=0))
+    sleep_time = int(request.config.getoption('lb_sleep_time', default=60))
+
+    def log_in_user():
+        browser.get('https://directory.uw.edu/saml/login')
+        try:  # User may not be prompted to sign in, that's OK, we're still going through the IdP
+            browser.click(Locator(
+                search_method=SearchMethod.ID,
+                search_value='weblogin_netid',
+            ))
+            browser.send_inputs(
+                netid,
+                secrets.test_accounts.password.get_secret_value(),
+            )
+            browser.click(Locator(
+                search_method=SearchMethod.ID,
+                search_value='submit_button',
+            ))
+        except Exception:
+            browser.snap()
+        finally:
+            try:  # The population-option-all element is only present when a user is signed in
+                browser.wait_for(Locator(
+                    search_method=SearchMethod.ID,
+                    search_value='population-option-all',
+                ))
+            except Exception:
+                browser.snap()
+                pass
+
+    def log_out_user():
+        browser.get('https://directory.uw.edu/saml/logout')
+        browser.snap()
+
+    for _ in range(num_loops):
+        log_in_user()
+        log_out_user()
+        time.sleep(sleep_time)


### PR DESCRIPTION
Preview:

![Screen Shot 2022-02-03 at 2 31 46 PM](https://user-images.githubusercontent.com/1092941/152443168-65a9a8ea-54f7-4feb-9dc9-8e30c3471b07.png)

Example run (running 5 attempts w/ 5 seconds each): https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/1792108277

Note that because I renamed the workflow file, the workflow listed in the Actions index (and in the doc herein) will not work until this PR is merged.