### PR TITLE
[AUTH-1571] Test SP Lifecycle Management Update (Part 1)

### DIFF
--- a/.github/workflows/cache-new-image.yml
+++ b/.github/workflows/cache-new-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         env:
-          tag: ${{ github.ref == 'refs/heads/main' && 'latest' || 'dry-run-latest' }}
+          tag: ${{ github.ref == 'refs/heads/mainline' && 'latest' || 'dry-run-latest' }}
         with:
           context: .
           push: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,14 +60,6 @@ def manage_test_service_providers(settings, utils):
         utils.sp_aws_operations.wait_for_ip_propagation()
     else:
         logging.info("Service provider instances will be started as-needed.")
-    try:
-        yield
-    finally:
-        if not settings.test_options.skip_test_service_provider_stop:
-            logging.info("Stopping all test service provider instances.")
-            utils.sp_aws_operations.stop_instances()
-        else:
-            logging.info("Leaving all active test service provider instances running.")
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,15 @@ def manage_test_service_providers(settings, utils):
     if not settings.test_options.skip_test_service_provider_start:
         logging.info("Starting all test service provider instances.")
         utils.sp_aws_operations.start_instances()
-        utils.sp_aws_operations.update_instance_a_records()
-        utils.sp_aws_operations.wait_for_ip_propagation()
+        record_sets = utils.sp_aws_operations.record_sets
+        service_providers = utils.sp_aws_operations.service_providers.keys()
+        service_providers = [
+            sp for sp in service_providers if
+            utils.sp_aws_operations.dns_record_requires_update(record_sets, sp)
+        ]
+        if service_providers:
+            utils.sp_aws_operations.update_instance_a_records(*service_providers)
+            utils.sp_aws_operations.wait_for_ip_propagation(*service_providers)
     else:
         logging.info("Service provider instances will be started as-needed.")
 

--- a/tests/sp_manager.py
+++ b/tests/sp_manager.py
@@ -51,8 +51,14 @@ def start(service_providers, settings_file, settings_env, dry_run):
                                       settings.aws_hosted_zone,
                                       utils)
     op.start_instances(*service_providers, dry_run=dry_run)
-    op.update_instance_a_records(*service_providers, dry_run=dry_run)
-    op.wait_for_ip_propagation(*service_providers, dry_run=dry_run)
+    record_sets = utils.sp_aws_operations.record_sets
+    outdated_dns_records = [
+        sp for sp in service_providers
+        if utils.sp_aws_operations.dns_record_requires_update(record_sets, sp)
+    ]
+    if outdated_dns_records:
+        op.update_instance_a_records(*outdated_dns_records, dry_run=dry_run)
+        op.wait_for_ip_propagation(*outdated_dns_records, dry_run=dry_run)
 
 
 @cli.command()


### PR DESCRIPTION
- Tests no longer try to shut down test SPs
- Tests now check whether SP is active before trying to activate
- Tests now check whether SP IP address matches DNS before trying to update DNS
- Fixes issue where cached image was not being updated upon acceptance into the mainline branch

This results in a lot less churn in our AWS resources, and eliminates a large amount of instability in the test ecosystem. I have gotten a few complete successes when running with these updates. 

The next update will include a scheduled workflow to shut down test SPs after automated tests complete, and also at the end of the work day (in case anyone ran manual tests but failed to turn off the test SPs). 

- Success 1 https://identity-artifact.iamdev.s.uw.edu/web-tests/idp/workflow_dispatch/tomthorogood/2022.02.25-11.24.14/index.html
- Success 2 https://identity-artifact.iamdev.s.uw.edu/web-tests/idp/workflow_dispatch/tomthorogood/2022.02.25-10.50.44/index.html

Some tests are still intermittently failing and those failures are still being investigated. This change simply fixes a small part of the larger issue(s) at play.