### PR TITLE
Add workflow to stop test SPs

### DIFF
--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -14,6 +14,7 @@ on:
   schedule:
     # The cron string must be quoted!
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+    # Do not change this without also changing stop-test-service-providers.yml
     - cron: '0 10 * * *'  # 3am PDT, 2am PST
 
   workflow_dispatch:

--- a/.github/workflows/cache-new-image.yml
+++ b/.github/workflows/cache-new-image.yml
@@ -1,8 +1,11 @@
+name: Re-build and upload a new image using given branch.
 on:
   push:
     branches:
       - mainline
       - run-cache-new-image-workflow
+  workflow_dispatch:  # Allows running from the Github Actions UI
+
 
 jobs:
   cache-new-image:

--- a/.github/workflows/stop-test-service-providers.yml
+++ b/.github/workflows/stop-test-service-providers.yml
@@ -1,0 +1,45 @@
+name: Turn off test service provider VMs
+
+on:
+  push:
+    branches:
+      - stop-test-service-providers
+  workflow_dispatch:  # Allows running from the Github Actions UI
+  schedule:
+    # The cron strings must be quoted!
+    # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+
+    # Do not change this without also changing automated-idp-web-tests.yml.
+    # This corresponds to 30 minutes after the tests start the servers,
+    # which gives tests more than enough time to complete.
+    # TODO: Find a better way of doing this! This is fine for now, but
+    #       there just has to be a cleaner solution.
+    - cron: '30 10 * * *'  # 3:30am PDT, 2:30am PST
+
+    # This can be updated any time; it's supposed to correspond roughly
+    # to the end of the workday. Maybe update it when the time changes
+    # so that it's always 5:30? (Low effort but probably unnecessary maintenance.)
+    - cron: '30 1 * * *'  # 6:30pm PDT, 5:30pm PST
+
+env:
+  AWS_DEFAULT_REGION: us-west-2  # Oregon; where EC2 instances are held
+
+jobs:
+  stop-service-providers:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uwit-iam/idp-web-tests:latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: 'google-github-actions/auth@v0'
+      name: 'Authenticate to Google Cloud'
+      with:
+        credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    - run: |
+        python -m tests.sp_manager stop


### PR DESCRIPTION
Adds a workflow to stop test service providers.

This workflow will be able to run manually from the Github UI, and will also run 30 minutes after the automated tests start, as well as at 5:30pm (or 6:30, depending on the time of year). 

Unfortunately, I cannot fully document this until it is merged, because some of the github links for the workflow won't be generated until then.

---

[Example](https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/1911905178):

```
> Run python -m tests.sp_manager stop
2022-02-28 18:23:30,238: Requesting stop of instances: ['i-044079a092737333c', 'i-08135521eea1301af', 'i-05a580a7a07a762e6', 'i-01adcaed09b14a248', 'i-050ad39ec3c728916', 'i-0a12f5aeef6a3f08f', 'i-0c31d2d296e0f128e']
2022-02-28 18:23:30,804: Waiting for instances to shut down.
2022-02-28 18:23:31,202: All requested instances have stopped.
```