### PR TITLE
Fix service name to match service in base compose file.

### DIFF
--- a/strict-host-override.docker-compose.yml
+++ b/strict-host-override.docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  chrome:
+  selenium:
     environment:
       EXTRA_HOST: ${EXTRA_HOST}
     extra_hosts:


### PR DESCRIPTION
This fixes the issue with the tests failing to launch, and we've tested that the host override behavior works as intended.

Tests may still fail with this PR, but those failures are unrelated to the fix proposed here.