### PR TITLE
Fix daily test failures with python 10 compatible gcloud update

### DIFF
--- a/.github/workflows/scheduled-idp-web-tests.yml
+++ b/.github/workflows/scheduled-idp-web-tests.yml
@@ -45,7 +45,7 @@ jobs:
           workflow_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
-      - uses: UWIT-IAM/actions/configure-gcloud-docker@0.1
+      - uses: UWIT-IAM/actions/configure-gcloud-docker-gcloud-v101@0.1.17
         with:
           gcloud-token: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
 


### PR DESCRIPTION
Closes GH-27. Updated gcloud version used by `scheduled-idp-web-tests.yml`
Currently, there isn't a way to force this workflow to run, but this same error popped up in other workflows in other repos, so I'm pretty confident.