### PR TITLE
replace the deprecated 'set-output' with GITHUB_OUTPUT

### DIFF
--- a/.github/scripts/funcs.sh
+++ b/.github/scripts/funcs.sh
@@ -46,5 +46,5 @@ function get-report-output-path() {
 function set-output() {
   local output_name="$1"
   local payload="$2"
-  echo "::set-output name=$output_name::$payload"
+  echo "$output_name=$payload" >> $GITHUB_OUTPUT
 }

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -158,8 +158,8 @@ jobs:
           fi
 
           # Only upload artifacts if the test suite actually ran.
-          echo "::set-output name=test-status::$test_status"
-          echo "::set-output name=upload-artifacts::true"
+          echo "test-status=$test_status" >> $GITHUB_OUTPUT
+          echo "upload-artifacts=true" >> $GITHUB_OUTPUT
           exit  $exit_status
 
         name: Run UW ${{ env.IDP_ENV }} IdP Web Tests

--- a/.github/workflows/scheduled-idp-web-tests.yml
+++ b/.github/workflows/scheduled-idp-web-tests.yml
@@ -35,11 +35,11 @@ jobs:
           timestamp=$(date "+%Y.%d.%m-%H.%m.%S")
           storyboard_path="idp/schedule/${{ matrix.idp_env }}/${timestamp}"
           report_dir="web-tests/${storyboard_path}"
-          echo ::set-output name=timestamp::${timestamp}
-          echo ::set-output name=storyboard_path::${storyboard_path}
-          echo ::set-output name=report_dir::${report_dir}
-          echo ::set-output name=storyboard_link::${storyboard_url}/${report_dir}/index.html
-          echo ::set-output name=workflow_link::${{ env.workflow_link }}
+          echo timestamp=${timestamp} >> $GITHUB_OUTPUT
+          echo storyboard_path=${storyboard_path} >> $GITHUB_OUTPUT
+          echo report_dir=${report_dir} >> $GITHUB_OUTPUT
+          echo storyboard_link=${storyboard_url}/${report_dir}/index.html >> $GITHUB_OUTPUT
+          echo workflow_link=${{ env.workflow_link }} >> $GITHUB_OUTPUT
         env:
           storyboard_url: https://identity-artifact.iamdev.s.uw.edu/
           workflow_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -95,7 +95,7 @@ jobs:
           then
             mkdir -pv ${{ steps.config.outputs.report_dir }}
             cp -r webdriver-report/* ${{ steps.config.outputs.report_dir }}
-            echo ::set-output name=upload_storyboards::'true'
+            echo upload_storyboards='true' >> $GITHUB_OUTPUT
           fi
         id: post-run
 


### PR DESCRIPTION
Closes GH-29.  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
`set-output` is used all over the place. Most instances were causing warnings which will eventually cause errors.
Like https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/3897287853/jobs/6654799961#step:7:43
I left [a few ](https://github.com/UWIT-IAM/uw-idp-web-tests/blob/mainline/.github/scripts/configure-workflow.sh#L115)that I don't think are causing this warning.

I'll still have to update usage of `set-output` in the [actions repo](https://github.com/UWIT-IAM/actions), and after that, hopefully we won't have these warnings and eventual failures. 