### PR TITLE
[GH-31] update version of 'docker/build-push-action' for 'save-state' warning

### DIFF
--- a/.github/workflows/cache-new-image.yml
+++ b/.github/workflows/cache-new-image.yml
@@ -23,7 +23,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         env:
           tag: ${{ github.ref == 'refs/heads/mainline' && 'latest' || 'dry-run-latest' }}
         with:


### PR DESCRIPTION
Closes GH-31 (see link for details)