### PR TITLE
[GH-33] fix warnings when merging into mainline.

### DIFF
--- a/.github/workflows/cache-new-image.yml
+++ b/.github/workflows/cache-new-image.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/cache-new-image.yml
+++ b/.github/workflows/cache-new-image.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Closes GH-33, warnings generated when merging into mainline. See Link for more info.
The reduction in warnings won't be seen til this branch is merged.