### PR TITLE
Fix to make the daily scheduled tests run again.

### DIFF
--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -193,7 +193,7 @@ jobs:
           path: web-tests
           destination: ${{ secrets.IDENTITY_ARTIFACT_BUCKET }}
         name: upload storyboards to identity-artifacts
-        uses: google-github-actions/upload-cloud-storage@v0.2.1
+        uses: google-github-actions/upload-cloud-storage@v1
 
       - if: ${{ always() && steps.run-tests.outputs.upload-artifacts == 'true' }}
         with:

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -78,6 +78,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -74,6 +74,11 @@ jobs:
       idp-env: ${{ steps.configure.outputs.idp-env }}
       idp-host: ${{ steps.configure.outputs.idp-host }}
       run-tests-args: ${{ steps.configure.outputs.run-tests-args }}
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     steps:
       - uses: actions/checkout@main
 
@@ -94,12 +99,16 @@ jobs:
         run: |
           echo "SLACK_CANVAS_ID=${{ steps.configure.outputs.workflow-id }}" >> $GITHUB_ENV
 
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        name: Set up gcloud CLI and credentials
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
         with:
-          project_id: ${{ secrets.IAM_GCR_REPO }}
-          service_account_key: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '>= 363.0.0'
 
       - name: Initialize slack workflow canvas
         env:


### PR DESCRIPTION
Closes Github issue GH-35

The daily runs were not happening, that was a `glcoud` issue. Fixed that.
After that, the tests didn't run as intended, they were navigating but nothing was coming up at the requested URLs. @jdiverp [fixed](https://github.com/UWIT-IAM/uw-idp-web-tests/issues/35#issuecomment-1583499328) that second part.

After all that, due to the update to `gcloud`, the "Add storyboard link to pull request" job failed. I needed to add a permission `pull-requests: 'write'`.

Ran here https://github.com/UWIT-IAM/uw-idp-web-tests/actions/runs/5214227397
Slacked here https://uw-it.slack.com/archives/C9KPNR3TQ/p1686246693189869

There are still some deprecation warnings, but let's end the scope here and let the tests actually run :)
New issue to fix `set-ouput` here GH-37