### PR TITLE
[GH-38, GH-40] Fix the daily idp web tests - setup-gcloud version and iframe handling for prod/duo changes

### DIFF
--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -102,12 +102,12 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
 

--- a/.github/workflows/idp-login-request-generator.yml
+++ b/.github/workflows/idp-login-request-generator.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
       - env:

--- a/.github/workflows/idp-login-request-generator.yml
+++ b/.github/workflows/idp-login-request-generator.yml
@@ -34,13 +34,16 @@ jobs:
           - runner-id: 6
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}'
+          credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
+
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '>= 363.0.0'
       - env:
           load_balancer: ${{ github.event.inputs.load-balancer-ip }}
           num_loops: ${{ github.event.inputs.num-login-attempts }}

--- a/.github/workflows/stop-test-service-providers.yml
+++ b/.github/workflows/stop-test-service-providers.yml
@@ -34,12 +34,16 @@ jobs:
       id-token: 'write'
     steps:
     - uses: actions/checkout@v2
-    - uses: 'google-github-actions/auth@v0'
-      name: 'Authenticate to Google Cloud'
-      with:
-        credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '>= 363.0.0'
 
     - run: |
         python -m tests.sp_manager stop

--- a/.github/workflows/stop-test-service-providers.yml
+++ b/.github/workflows/stop-test-service-providers.yml
@@ -36,12 +36,12 @@ jobs:
     - uses: actions/checkout@v2
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.TEST_RUNNER_GOOGLE_TOKEN }}
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
 

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -1,14 +1,7 @@
 import pytest
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.wait import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 from tests.access_control import AccessControlTestBase
-from tests.helpers import Locators
 from tests.models import ServiceProviderInstance
-default_password = "IDPtestsR!fun"
-passcode = "377682022"
-
 
 class TestAuto2faCondAccessNonMember(AccessControlTestBase):
     @pytest.fixture(autouse=True)

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -1,7 +1,13 @@
 import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from tests.access_control import AccessControlTestBase
+from tests.helpers import Locators
 from tests.models import ServiceProviderInstance
+default_password = "IDPtestsR!fun"
+passcode = "377682022"
 
 
 class TestAuto2faCondAccessNonMember(AccessControlTestBase):
@@ -18,6 +24,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_b(self):
@@ -33,6 +40,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp))
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_c(self):
@@ -49,6 +57,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='force'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_d(self):
@@ -64,6 +73,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
         sp = ServiceProviderInstance.diafine10
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfa'))
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_e(self):
@@ -81,6 +91,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_f(self):
@@ -92,4 +103,5 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='mfa'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/access_control/test_cond2fa_cond_nonmember_both.py
+++ b/tests/access_control/test_cond2fa_cond_nonmember_both.py
@@ -83,6 +83,7 @@ class TestCond2faNonMemberBoth(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_f(self):
@@ -94,4 +95,5 @@ class TestCond2faNonMemberBoth(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='mfa'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/access_control/test_cond_access_non_member.py
+++ b/tests/access_control/test_cond_access_non_member.py
@@ -86,4 +86,5 @@ class TestCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
+            self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
     def inner(
             current_browser: Chrome,
             passcode: str = default_passcode,
-            select_iframe: bool = True,
+            select_duo_push: bool = True,
             assert_success: Optional[bool] = None,
             assert_failure: Optional[bool] = None,
             match_service_provider: Optional[ServiceProviderInstance] = None,
@@ -186,8 +186,13 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
         :param current_browser: The browser you want to invoke these actions on.
         :param passcode: The passcode you want to enter; if not provided, will use the
             correct test instance passcode.
-        :param select_iframe: Defaults to True;
-                              you can toggle this to False if you are already in an iframe context.
+        :param select_duo_push: Defaults to True;
+                              you can toggle this to False if you are already in the duo push context.
+                              This was formerly known as select_iframe, but the iframe is being phased out.
+                              When select_duo_push is true, eval will find the path to the bypass code option. Prod will
+                              find the path to the duo iframe and then to the bypass code option. If we just need to
+                              re-enter/retry the bypass code, we are already at the bypass code field and don't need
+                              to find it again from scratch, and in those cases, we set select_duo_push to false.
         :param assert_success: Optional. Will ensure that the result was a successful
                                sign in attempt. If not overridden, will default to True
                                if the passcode being entered is the correct passcode.
@@ -212,7 +217,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
         if assert_failure is None:
             assert_failure = not passcode_matches_default
 
-        if select_iframe and test_env == 'prod':
+        if select_duo_push and test_env == 'prod':
             current_browser.wait_for_tag('p', 'Use your 2FA device.')
             iframe = current_browser.wait_for(Locators.iframe)
             current_browser.switch_to.frame(iframe)
@@ -228,7 +233,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             current_browser.execute_script("document.getElementById('passcode').click();")
             sleep(5)
 
-        if select_iframe and test_env == 'eval':
+        if select_duo_push and test_env == 'eval':
             current_browser.wait_for_tag('a', 'Other options').click()
             current_browser.wait_for_tag('b', 'Other options to log in')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,8 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             sleep(5)
 
         if select_duo_push and test_env == 'eval':
+            wait = WebDriverWait(current_browser, 10)
+            wait.until(EC.element_to_be_clickable((By.XPATH, "//a[contains(text(), 'Other options')]")))
             current_browser.wait_for_tag('a', 'Other options').click()
             current_browser.wait_for_tag('b', 'Other options to log in')
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,10 +39,7 @@ class Locators:
     submit_button = Locator(search_method=By.ID, search_value='submit_button')
     logout_button = Locator(search_method=By.CSS_SELECTOR, search_value='input[value="Logout"]')
     iframe = Locator(search_method=By.ID, search_value='duo_iframe')
-    passcode_button = Locator(search_method=By.CSS_SELECTOR,
-                              search_value='div.row.display-flex.method-label[value="Bypass code"]')
-    # passcode_button = Locator(search_method=By.CSS_SELECTOR, search_value='div[value="Bypass code"]')
-    # <div class="row display-flex method-label">Bypass code</div>
+    passcode_button = Locator(search_method=By.ID, search_value='passcode')
 
 
 def lookup_domain_ip(domain: str):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,7 +39,10 @@ class Locators:
     submit_button = Locator(search_method=By.ID, search_value='submit_button')
     logout_button = Locator(search_method=By.CSS_SELECTOR, search_value='input[value="Logout"]')
     iframe = Locator(search_method=By.ID, search_value='duo_iframe')
-    passcode_button = Locator(search_method=By.ID, search_value='passcode')
+    passcode_button = Locator(search_method=By.CSS_SELECTOR,
+                              search_value='div.row.display-flex.method-label[value="Bypass code"]')
+    # passcode_button = Locator(search_method=By.CSS_SELECTOR, search_value='div[value="Bypass code"]')
+    # <div class="row display-flex method-label">Bypass code</div>
 
 
 def lookup_domain_ip(domain: str):

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -142,6 +142,7 @@ class Test2FASessionCRNs:
         self.sp = ServiceProviderInstance.diafine6
         self.shib_mfa_url = sp_shib_url(self.sp, append='mfa')
 
+    @pytest.mark.usefixtures('skip_if_eval')
     def test_2fa_session_single_crn(self, netid2, enter_duo_passcode):
         """
         2FA-8 part a. 2FA session using an acct with a Single CRN.
@@ -154,6 +155,7 @@ class Test2FASessionCRNs:
             self.browser.wait_for_tag('p', "Using your 'sptest03' Duo identity.")
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
+    @pytest.mark.usefixtures('skip_if_eval')
     def test_2fa_session_multiple_crn(self, netid10, enter_duo_passcode):
         """
         2FA-8 part b. 2FA session using an acct with multiple CRNs.

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -5,13 +5,10 @@ https://wiki.cac.washington.edu/display/SMW/IAM+Team+Wiki
 
 2FA-1 thru 2FA-11. 2FA-8b and 2FA-10 are not yet automatable.
 """
-from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_recorder.browser import Chrome
 from tests.helpers import Locators
 from tests.models import ServiceProviderInstance
 import pytest
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 
 
 def test_new_session_no_duo(utils, sp_url, sp_domain, secrets, netid, test_env, fresh_browser, sp_shib_url):
@@ -94,8 +91,7 @@ class TestNew2FASessionAndForcedReAuth:
             self.enter_duo_passcode(self.browser,
                                     passcode=passcode,
                                     assert_failure=True)
-            print('a')
-            self.enter_duo_passcode_2(self.browser, select_iframe=False, match_service_provider=sp, assert_success=True)
+            self.enter_duo_passcode(self.browser, select_iframe=False, match_service_provider=sp, assert_success=True, retry=True)
 
     def test_forced_reauth_2fa(self):
         """2 FA-5 SSO to new forced reauth 2FA SP with an existing 2FA session"""

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -69,7 +69,7 @@ class TestNew2FASessionAndForcedReAuth:
     browser: Chrome
 
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, sp_shib_url, sp_domain, secrets, netid3, test_env, enter_duo_passcode, enter_duo_passcode_2):
+    def initialize(self, utils, sp_shib_url, sp_domain, secrets, netid3, test_env, enter_duo_passcode):
         self.utils = utils
         self.sp_shib_url = sp_shib_url
         self.sp_domain = sp_domain
@@ -77,7 +77,6 @@ class TestNew2FASessionAndForcedReAuth:
         self.password = secrets.test_accounts.password.get_secret_value()
         self.test_env = test_env
         self.enter_duo_passcode = enter_duo_passcode
-        self.enter_duo_passcode_2 = enter_duo_passcode_2
 
     def test_new_session_2fa_invalid_token_retry(self, log_in_netid):
         """
@@ -91,7 +90,7 @@ class TestNew2FASessionAndForcedReAuth:
             self.enter_duo_passcode(self.browser,
                                     passcode=passcode,
                                     assert_failure=True)
-            self.enter_duo_passcode(self.browser, select_iframe=False, match_service_provider=sp, assert_success=True, retry=True)
+            self.enter_duo_passcode(self.browser, select_duo_push=False, match_service_provider=sp, assert_success=True, retry=True)
 
     def test_forced_reauth_2fa(self):
         """2 FA-5 SSO to new forced reauth 2FA SP with an existing 2FA session"""

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -33,10 +33,11 @@ class TestNew2FASessionAndExisting2FASession:
     """
 
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, sp_domain, sp_shib_url):
+    def initialize(self, utils, sp_domain, sp_shib_url, test_env):
         self.utils = utils
         self.sp_domain = sp_domain
         self.sp_shib_url = sp_shib_url
+        self.test_env = test_env
 
     def test_2fa_signin(self, secrets, netid3, enter_duo_passcode, log_in_netid):
         """

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -5,10 +5,13 @@ https://wiki.cac.washington.edu/display/SMW/IAM+Team+Wiki
 
 2FA-1 thru 2FA-11. 2FA-8b and 2FA-10 are not yet automatable.
 """
+from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_recorder.browser import Chrome
 from tests.helpers import Locators
 from tests.models import ServiceProviderInstance
 import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
 
 def test_new_session_no_duo(utils, sp_url, sp_domain, secrets, netid, test_env, fresh_browser, sp_shib_url):
@@ -69,7 +72,7 @@ class TestNew2FASessionAndForcedReAuth:
     browser: Chrome
 
     @pytest.fixture(autouse=True)
-    def initialize(self, utils, sp_shib_url, sp_domain, secrets, netid3, test_env, enter_duo_passcode):
+    def initialize(self, utils, sp_shib_url, sp_domain, secrets, netid3, test_env, enter_duo_passcode, enter_duo_passcode_2):
         self.utils = utils
         self.sp_shib_url = sp_shib_url
         self.sp_domain = sp_domain
@@ -77,6 +80,7 @@ class TestNew2FASessionAndForcedReAuth:
         self.password = secrets.test_accounts.password.get_secret_value()
         self.test_env = test_env
         self.enter_duo_passcode = enter_duo_passcode
+        self.enter_duo_passcode_2 = enter_duo_passcode_2
 
     def test_new_session_2fa_invalid_token_retry(self, log_in_netid):
         """
@@ -90,10 +94,8 @@ class TestNew2FASessionAndForcedReAuth:
             self.enter_duo_passcode(self.browser,
                                     passcode=passcode,
                                     assert_failure=True)
-            self.enter_duo_passcode(self.browser,
-                                    select_iframe=False,
-                                    match_service_provider=sp,
-                                    assert_success=True)
+            print('a')
+            self.enter_duo_passcode_2(self.browser, select_iframe=False, match_service_provider=sp, assert_success=True)
 
     def test_forced_reauth_2fa(self):
         """2 FA-5 SSO to new forced reauth 2FA SP with an existing 2FA session"""
@@ -174,11 +176,14 @@ class Test2FASessionCRNs:
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
 
+@pytest.mark.usefixtures('skip_if_eval')
 def test_remember_me_cookie(
         utils, sp_shib_url, sp_url, log_in_netid,
         sp_domain, secrets, netid3, test_env, fresh_browser, enter_duo_passcode):
     """
     2FA-9 Remember me cookie
+
+    Only runs when running tests against prod, for now. Eval does not yet support the uw-rememberme cookie.
     """
     password = secrets.test_accounts.password.get_secret_value()
 
@@ -221,10 +226,13 @@ def test_remember_me_cookie(
         log_in_netid(fresh_browser, netid3, match_service_provider=sp)
 
 
+@pytest.mark.usefixtures('skip_if_eval')
 def test_forget_me_self_service(utils, sp_url, sp_domain, secrets, netid3, test_env, enter_duo_passcode,
                                 fresh_browser, sp_shib_url):
     """
     2FA-11 Forget me (self-service)
+
+    Only runs when running tests against prod, for now. Eval does not yet support the uw-rememberme cookie.
     """
     idp_env = ''
     if test_env == "eval":


### PR DESCRIPTION
- `setup-gcloud` stopped working - fixed.
- Switching from focus on the iframe to default content wasn't happening anymore in some cases. - fixed.
- eval has implemented the new duo 2fa workflow, adjustments were made for that flow.

closes GH-38
closes GH-40