### PR TITLE
[GH-41] Update eval and prod tests to accomodate for new "remember me" style cookie, and a few other ancillary/supporting changes.

### DIFF
--- a/tests/access_control/test_auto_2fa.py
+++ b/tests/access_control/test_auto_2fa.py
@@ -45,7 +45,7 @@ class TestAuto2fa(AccessControlTestBase):
             with self.browser.tab_context():
                 self.browser.get(self.sp_shib_url(sp, append='force'))
                 self.log_in_netid(self.browser, netid3, match_service_provider=sp, assert_success=False)
-                self.enter_duo_passcode(self.browser)
+                self.enter_duo_passcode(self.browser, is_this_your_device_screen=False)
 
     def test_auto_2fa_d(self, netid3):
         """

--- a/tests/access_control/test_auto_2fa.py
+++ b/tests/access_control/test_auto_2fa.py
@@ -78,7 +78,7 @@ class TestAuto2fa(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, netid3, match_service_provider=sp, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_auto_2fa_f(self, netid3):
         """

--- a/tests/access_control/test_auto_2fa_cond_member.py
+++ b/tests/access_control/test_auto_2fa_cond_member.py
@@ -50,7 +50,7 @@ class TestCondAccessMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='force'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_d(self):
         """

--- a/tests/access_control/test_auto_2fa_cond_member.py
+++ b/tests/access_control/test_auto_2fa_cond_member.py
@@ -81,7 +81,7 @@ class TestCondAccessMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_f(self):
         """

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -23,12 +23,6 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
-
-            # if self.test_env == 'eval':
-            #     self.wait = WebDriverWait(self.browser, 10)
-            #     element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
-            #                                                            "text()='No, other people use this device']")))
-            #     element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_b(self):
@@ -60,7 +54,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='force'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, assert_success=False)
+            self.enter_duo_passcode(self.browser, assert_success=False, is_this_your_device_screen=False)
             self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -24,11 +24,11 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
 
-            if self.test_env == 'eval':
-                self.wait = WebDriverWait(self.browser, 10)
-                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
-                                                                       "text()='No, other people use this device']")))
-                element.click()
+            # if self.test_env == 'eval':
+            #     self.wait = WebDriverWait(self.browser, 10)
+            #     element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+            #                                                            "text()='No, other people use this device']")))
+            #     element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_b(self):
@@ -45,11 +45,6 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp))
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
-            if self.test_env == 'eval':
-                self.wait = WebDriverWait(self.browser, 10)
-                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
-                                                                       "text()='No, other people use this device']")))
-                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_c(self):
@@ -67,11 +62,6 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
-            if self.test_env == 'eval':
-                self.wait = WebDriverWait(self.browser, 10)
-                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
-                                                                       "text()='No, other people use this device']")))
-                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_d(self):
@@ -104,7 +94,7 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, assert_success=False)
+            self.enter_duo_passcode(self.browser, assert_success=False, is_this_your_device_screen=False)
             self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
@@ -118,9 +108,4 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
-            if self.test_env == 'eval':
-                self.wait = WebDriverWait(self.browser, 10)
-                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
-                                                                       "text()='No, other people use this device']")))
-                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/access_control/test_auto_2fa_cond_non_member.py
+++ b/tests/access_control/test_auto_2fa_cond_non_member.py
@@ -1,12 +1,17 @@
 import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 from tests.access_control import AccessControlTestBase
 from tests.models import ServiceProviderInstance
+from selenium.webdriver.support import expected_conditions as EC
+
 
 class TestAuto2faCondAccessNonMember(AccessControlTestBase):
     @pytest.fixture(autouse=True)
-    def initialize(self, netid3):
+    def initialize(self, netid3, test_env):
         self.netid = netid3
+        self.test_env = test_env
 
     def test_a(self):
         """
@@ -18,6 +23,12 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
+
+            if self.test_env == 'eval':
+                self.wait = WebDriverWait(self.browser, 10)
+                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+                                                                       "text()='No, other people use this device']")))
+                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_b(self):
@@ -34,6 +45,11 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.browser.get(self.sp_shib_url(sp))
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
+            if self.test_env == 'eval':
+                self.wait = WebDriverWait(self.browser, 10)
+                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+                                                                       "text()='No, other people use this device']")))
+                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_c(self):
@@ -51,6 +67,11 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
+            if self.test_env == 'eval':
+                self.wait = WebDriverWait(self.browser, 10)
+                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+                                                                       "text()='No, other people use this device']")))
+                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 
     def test_d(self):
@@ -97,4 +118,9 @@ class TestAuto2faCondAccessNonMember(AccessControlTestBase):
             self.log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser, assert_success=False)
             self.browser.switch_to.default_content()
+            if self.test_env == 'eval':
+                self.wait = WebDriverWait(self.browser, 10)
+                element = self.wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+                                                                       "text()='No, other people use this device']")))
+                element.click()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
+++ b/tests/access_control/test_cond2fa_cond_acc_group_member_2fa_non_member.py
@@ -79,7 +79,7 @@ class TestCond2faAccGroupNonMember2fa(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_f(self):
         """

--- a/tests/access_control/test_cond2fa_cond_member_both.py
+++ b/tests/access_control/test_cond2fa_cond_member_both.py
@@ -81,7 +81,7 @@ class TestCond2faCondGroupMemberBoth(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_f(self):
         """

--- a/tests/access_control/test_cond2fa_cond_member_both.py
+++ b/tests/access_control/test_cond2fa_cond_member_both.py
@@ -50,7 +50,7 @@ class TestCond2faCondGroupMemberBoth(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='force'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_d(self):
         """

--- a/tests/access_control/test_cond2fa_cond_nonmember_both.py
+++ b/tests/access_control/test_cond2fa_cond_nonmember_both.py
@@ -82,7 +82,7 @@ class TestCond2faNonMemberBoth(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, assert_success=False)
+            self.enter_duo_passcode(self.browser, assert_success=False, is_this_your_device_screen=False)
             self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')
 

--- a/tests/access_control/test_cond2fa_group_member.py
+++ b/tests/access_control/test_cond2fa_group_member.py
@@ -81,7 +81,7 @@ class TestCond2faGroupMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_f(self):
         """

--- a/tests/access_control/test_cond2fa_group_member.py
+++ b/tests/access_control/test_cond2fa_group_member.py
@@ -49,7 +49,7 @@ class TestCond2faGroupMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='force'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_d(self):
         """

--- a/tests/access_control/test_cond2fa_non_member.py
+++ b/tests/access_control/test_cond2fa_non_member.py
@@ -75,7 +75,7 @@ class TestCond2faGroupMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
     def test_f(self):
         """

--- a/tests/access_control/test_cond_access_non_member.py
+++ b/tests/access_control/test_cond_access_non_member.py
@@ -85,6 +85,6 @@ class TestCondAccessNonMember(AccessControlTestBase):
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.log_in_netid(self.browser, self.netid, assert_success=False)
-            self.enter_duo_passcode(self.browser, assert_success=False)
+            self.enter_duo_passcode(self.browser, assert_success=False, is_this_your_device_screen=False)
             self.browser.switch_to.default_content()
             self.browser.wait_for_tag('p', 'You are not authorized to access the application:')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,39 +238,61 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             wait.until(EC.element_to_be_clickable((By.XPATH, "//a[contains(text(), 'Other options')]")))
             current_browser.wait_for_tag('a', 'Other options').click()
             current_browser.wait_for_tag('b', 'Other options to log in')
+            print('select_duo_push and test_env == eval')
 
         if test_env == 'eval':
             wait = WebDriverWait(current_browser, 10)
             if assert_success and retry:
+                print('eval, assert_success, retry')
                 element = wait.until(EC.element_to_be_clickable((By.XPATH,
                                                                  "//input[contains(@id, 'passcode-input')]")))
             else:
-                element = wait.until(EC.visibility_of_element_located((By.XPATH, "//div[contains(text(), 'Bypass code') "
-                                                                                 "and "
-                                                                                 "contains( "
-                                                                       "@class, 'row') and contains(@class, "
-                                                                                 "'display-flex') ]"))
-                                 )
+                print('not eval, assert_success, retry')
+                element = wait.until(EC.visibility_of_element_located((By.XPATH,
+                                                                       "//div[contains(text(), 'Bypass code') and "
+                                                                       "contains(@class, 'row') and contains(@class, "
+                                                                       "'display-flex')]")))
+                print('done with not eval, assert_success, retry')
+
             current_browser.snap()
             element.click()
+            print('test env is still eval')
             current_browser.snap()
             if assert_success and retry:
+                print('assert_success and retry')
                 current_browser.execute_script("arguments[0].value = '';", element)
                 current_browser.snap()
+            print('test env is still eval, again')
             current_browser.send_inputs(passcode)
             current_browser.snap()
-            current_browser.snap()
             current_browser.wait_for_tag('button', 'Verify').click()
-
+            sleep(5)
             current_browser.snap()
+            print('test env is still eval, again and again')
+            print(f'assert_success = {assert_success} and test_env == {test_env}')
+            if assert_success and test_env == 'eval':
+                print('assert_success and test_env == eval')
+                element = wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
+                                                                       "text()='No, other people use this device']")))
+                element.click()
+            sleep(5)
+            print('test env is still eval, again and again and again')
+            current_browser.snap()
+            # element.click()
 
         if assert_success:
+            print('yes, assert')
             if test_env == 'prod':
                 current_browser.switch_to.default_content()
+            print('yes, still assert')
+            current_browser.snap()
             sp = sp_domain(match_service_provider) if match_service_provider else ''
             current_browser.wait_for_tag('h2', f'{sp} sign-in success!')
         elif assert_failure:
+            sleep(5)
+            print('actually, assert failure')
             if test_env == 'eval':
+                current_browser.snap()
                 current_browser.wait_for_tag('span', 'Invalid passcode')
             else:
                 current_browser.wait_for_tag('span', 'Incorrect passcode. Enter a passcode from Duo Mobile.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,6 @@ def clear_passcode(current_browser: Chrome, element):
     clear the data in the passcode field so you can try a different passcode
     """
     current_browser.execute_script("arguments[0].value = '';", element)
-    current_browser.snap()
 
 
 @pytest.fixture
@@ -200,7 +199,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             match_service_provider: Optional[ServiceProviderInstance] = None,
             retry: Optional[bool] = False,
             is_this_your_device_screen: Optional[bool] = True,
-            select_this_is_my_device: Optional[bool] = False
+            select_this_is_my_device: Optional[bool] = False,
     ):
         """
         eval and prod flows have 2 different expectations, since duo is updated on eval only, prod to come soon.
@@ -256,7 +255,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             )
             current_browser.snap()
             current_browser.execute_script("document.getElementById('passcode').click();")
-            sleep(5)
+            sleep(5)  # this sleep will go away after we copy the universal prompt 2fa to prod.
 
         if select_duo_push and test_env == 'eval':
             duo_push(current_browser)
@@ -282,8 +281,6 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             current_browser.send_inputs(passcode)
             current_browser.snap()
             current_browser.wait_for_tag('button', 'Verify').click()
-            sleep(5)
-            current_browser.snap()
 
             if test_env == 'eval' and is_this_your_device_screen:
                 if select_this_is_my_device:
@@ -295,19 +292,15 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
                                                               "device']")))
 
                 element.click()
-            sleep(5)
             current_browser.snap()
 
         if assert_success:
             if test_env == 'prod':
                 current_browser.switch_to.default_content()
-            current_browser.snap()
             sp = sp_domain(match_service_provider) if match_service_provider else ''
             current_browser.wait_for_tag('h2', f'{sp} sign-in success!')
         elif assert_failure:
-            sleep(5)
             if test_env == 'eval':
-                current_browser.snap()
                 current_browser.wait_for_tag('span', 'Invalid passcode')
             else:
                 current_browser.wait_for_tag('span', 'Incorrect passcode. Enter a passcode from Duo Mobile.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,8 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             assert_failure: Optional[bool] = None,
             match_service_provider: Optional[ServiceProviderInstance] = None,
             retry: Optional[bool] = False,
-            is_this_your_device_screen: Optional[bool] = True
+            is_this_your_device_screen: Optional[bool] = True,
+            select_this_is_my_device: Optional[bool] = False
     ):
         """
         eval and prod flows have 2 different expectations, since duo is updated on eval only, prod to come soon.
@@ -231,6 +232,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
                                              "is this your device". In a small number of cases, you won't see this
                                              screen, ex: an auto 2fa where the user already has given an answer prior
                                              and then switches diafines.
+        :param select_this_is_my_device: Optional. Defaults to False, since in most cases we don't want duo.com to set a rememberme style cookie.
         """
         passcode_matches_default = passcode == default_passcode
 
@@ -284,9 +286,14 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             current_browser.snap()
 
             if test_env == 'eval' and is_this_your_device_screen:
-                element = wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' "
-                                                                           "and text()='No, other people use this "
-                                                                           "device']")))
+                if select_this_is_my_device:
+                    element = wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='trust-browser-button']")))
+                else:
+                    element = wait.until(
+                        EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' "
+                                                              "and text()='No, other people use this "
+                                                              "device']")))
+
                 element.click()
             sleep(5)
             current_browser.snap()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,8 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             assert_success: Optional[bool] = None,
             assert_failure: Optional[bool] = None,
             match_service_provider: Optional[ServiceProviderInstance] = None,
-            retry: Optional[bool] = False
+            retry: Optional[bool] = False,
+            is_this_your_device_screen: Optional[bool] = True
     ):
         """
         :param current_browser: The browser you want to invoke these actions on.
@@ -207,6 +208,10 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
                                  (Providing this gives your tests a higher confidence.)
         :param retry: Optional. Tells the function if we are retrying the passcode after entering one that does
                                 not match.
+        :param is_this_your_device_screen: Optional. Defaults to True, since in most cases we will see the Duo screen that asks
+                                             "is this your device". In a small number of cases, you won't see this
+                                             screen, ex: an auto 2fa where the user already has given an answer prior
+                                             and then switches diafines.
         """
 
         passcode_matches_default = passcode == default_passcode
@@ -270,7 +275,7 @@ def enter_duo_passcode(secrets, sp_domain, test_env) -> Callable[..., NoReturn]:
             current_browser.snap()
             print('test env is still eval, again and again')
             print(f'assert_success = {assert_success} and test_env == {test_env}')
-            if assert_success and test_env == 'eval':
+            if assert_success and test_env == 'eval' and is_this_your_device_screen:
                 print('assert_success and test_env == eval')
                 element = wait.until(EC.element_to_be_clickable((By.XPATH, "//button[@id='dont-trust-browser-button' and "
                                                                        "text()='No, other people use this device']")))

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -92,6 +92,8 @@ class TestNew2FASessionAndForcedReAuth:
                                     assert_failure=True)
             self.enter_duo_passcode(self.browser, select_duo_push=False, match_service_provider=sp, assert_success=True, retry=True)
 
+    @pytest.mark.usefixtures('skip_if_eval')  # forced re-auth currently isn't in place at all for the same browser
+    # session
     def test_forced_reauth_2fa(self):
         """2 FA-5 SSO to new forced reauth 2FA SP with an existing 2FA session"""
         sp = ServiceProviderInstance.diafine12

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -156,8 +156,6 @@ class Test2FASessionCRNs:
             self.browser.get(self.shib_mfa_url)
             self.browser.send_inputs(netid2, self.password)
             self.browser.click(Locators.submit_button)
-            sleep(5)
-            self.browser.snap()
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
     def test_2fa_session_multiple_crn(self, netid10, enter_duo_passcode):
@@ -171,10 +169,7 @@ class Test2FASessionCRNs:
             self.browser.click(Locators.submit_button)
             self.browser.wait_for_tag('div', 'Select a UW NetID for 2nd factor authentication.')
             self.browser.find_element_by_xpath("//input[@value='sptest07']").click()
-            self.browser.snap()
             self.browser.click(Locators.submit_button)
-            sleep(5)
-            self.browser.snap()
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
 
@@ -209,10 +204,6 @@ def test_remember_me_cookie(
             wait.until(EC.element_to_be_clickable((By.XPATH, "//a[contains(text(), 'Other options')]")))
             enter_duo_passcode(fresh_browser, match_service_provider=sp, select_this_is_my_device=True)
 
-        # fresh_browser.wait_for_tag('p', 'Use your 2FA device.')
-        # fresh_browser.find_element_by_name('rememberme').click()
-
-
         # go to an idp site to retrieve the shib idp cookies
         fresh_browser.get(idp_url)
         fresh_browser.wait_for_tag('h1', 'not found')
@@ -232,7 +223,6 @@ def test_remember_me_cookie(
         assert 'shib_idp_session' not in cookie_names
         assert 'shib_idp_session_ss' not in cookie_names
 
-    sleep(5)
     sp = ServiceProviderInstance.diafine12
     with utils.using_test_sp(sp):
         fresh_browser.get(sp_shib_url(sp, append='mfa'))

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -144,7 +144,6 @@ class Test2FASessionCRNs:
         self.sp = ServiceProviderInstance.diafine6
         self.shib_mfa_url = sp_shib_url(self.sp, append='mfa')
 
-    @pytest.mark.usefixtures('skip_if_eval')
     def test_2fa_session_single_crn(self, netid2, enter_duo_passcode):
         """
         2FA-8 part a. 2FA session using an acct with a Single CRN.
@@ -154,10 +153,8 @@ class Test2FASessionCRNs:
             self.browser.get(self.shib_mfa_url)
             self.browser.send_inputs(netid2, self.password)
             self.browser.click(Locators.submit_button)
-            self.browser.wait_for_tag('p', "Using your 'sptest03' Duo identity.")
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
-    @pytest.mark.usefixtures('skip_if_eval')
     def test_2fa_session_multiple_crn(self, netid10, enter_duo_passcode):
         """
         2FA-8 part b. 2FA session using an acct with multiple CRNs.
@@ -171,7 +168,6 @@ class Test2FASessionCRNs:
             self.browser.find_element_by_xpath("//input[@value='sptest07']").click()
             self.browser.snap()
             self.browser.click(Locators.submit_button)
-            self.browser.wait_for_tag('p', "Using your 'sptest07' Duo identity.")
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
 

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -5,6 +5,11 @@ https://wiki.cac.washington.edu/display/SMW/IAM+Team+Wiki
 
 2FA-1 thru 2FA-11. 2FA-8b and 2FA-10 are not yet automatable.
 """
+from time import sleep
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from webdriver_recorder.browser import Chrome
 from tests.helpers import Locators
 from tests.models import ServiceProviderInstance
@@ -92,8 +97,6 @@ class TestNew2FASessionAndForcedReAuth:
                                     assert_failure=True, is_this_your_device_screen=False)
             self.enter_duo_passcode(self.browser, select_duo_push=False, match_service_provider=sp, assert_success=True, retry=True)
 
-    @pytest.mark.usefixtures('skip_if_eval')  # forced re-auth currently isn't in place at all for the same browser
-    # session
     def test_forced_reauth_2fa(self):
         """2 FA-5 SSO to new forced reauth 2FA SP with an existing 2FA session"""
         sp = ServiceProviderInstance.diafine12
@@ -101,7 +104,7 @@ class TestNew2FASessionAndForcedReAuth:
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
             self.browser.send_inputs(self.netid, self.password)
             self.browser.click(Locators.submit_button)
-            self.enter_duo_passcode(self.browser, match_service_provider=sp)
+            self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)
 
 
 def test_2fa_user_opt_in(utils, sp_shib_url, sp_domain, secrets, netid4, test_env, fresh_browser, enter_duo_passcode):
@@ -153,6 +156,8 @@ class Test2FASessionCRNs:
             self.browser.get(self.shib_mfa_url)
             self.browser.send_inputs(netid2, self.password)
             self.browser.click(Locators.submit_button)
+            sleep(5)
+            self.browser.snap()
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
     def test_2fa_session_multiple_crn(self, netid10, enter_duo_passcode):
@@ -168,10 +173,11 @@ class Test2FASessionCRNs:
             self.browser.find_element_by_xpath("//input[@value='sptest07']").click()
             self.browser.snap()
             self.browser.click(Locators.submit_button)
+            sleep(5)
+            self.browser.snap()
             enter_duo_passcode(self.browser, match_service_provider=self.sp)
 
 
-@pytest.mark.usefixtures('skip_if_eval')
 def test_remember_me_cookie(
         utils, sp_shib_url, sp_url, log_in_netid,
         sp_domain, secrets, netid3, test_env, fresh_browser, enter_duo_passcode):
@@ -190,31 +196,43 @@ def test_remember_me_cookie(
         fresh_browser.get(sp_shib_url(sp, append='mfa'))
         fresh_browser.send_inputs(netid3, password)
         fresh_browser.click(Locators.submit_button)
-        fresh_browser.wait_for_tag('p', 'Use your 2FA device.')
-        fresh_browser.find_element_by_name('rememberme').click()
-        enter_duo_passcode(fresh_browser, match_service_provider=sp)
-        # go to an idp site to retrieve the rememberme cookie
+        if test_env == 'prod':
+            fresh_browser.wait_for_tag('p', 'Use your 2FA device.')
+            fresh_browser.find_element_by_name('rememberme').click()
+            enter_duo_passcode(fresh_browser, match_service_provider=sp)
+
+        if test_env == 'eval':
+            """
+            Select the other duo option, to get to the bypass code option
+            """
+            wait = WebDriverWait(fresh_browser, 10)
+            wait.until(EC.element_to_be_clickable((By.XPATH, "//a[contains(text(), 'Other options')]")))
+            enter_duo_passcode(fresh_browser, match_service_provider=sp, select_this_is_my_device=True)
+
+        # fresh_browser.wait_for_tag('p', 'Use your 2FA device.')
+        # fresh_browser.find_element_by_name('rememberme').click()
+
+
+        # go to an idp site to retrieve the shib idp cookies
         fresh_browser.get(idp_url)
         fresh_browser.wait_for_tag('h1', 'not found')
 
         # look for these cookies:
-        # shib_idp_session, shib_idp_session_ss, and uw-rememberme-sptest03
+        # shib_idp_session, shib_idp_session_ss
 
         cookie_names = {cookie['name'] for cookie in fresh_browser.get_cookies()}
         assert 'shib_idp_session' in cookie_names
         assert 'shib_idp_session_ss' in cookie_names
-        assert 'uw-rememberme-sptest03' in cookie_names
 
         fresh_browser.get(f'{sp_url(sp)}/Shibboleth.sso/Logout?return={idp_url}/profile/Logout')
-        # After signing out of the IdP, the rememberme cookie should remain in the browser,
-        # but shib_idp_session* cookies should be gone.
+        # shib_idp_session* cookies should be gone.
         fresh_browser.wait_for_tag('span', 'Your UW NetID sign-in session has ended.')
 
         cookie_names = {cookie['name'] for cookie in fresh_browser.get_cookies()}
         assert 'shib_idp_session' not in cookie_names
         assert 'shib_idp_session_ss' not in cookie_names
-        assert 'uw-rememberme-sptest03' in cookie_names
 
+    sleep(5)
     sp = ServiceProviderInstance.diafine12
     with utils.using_test_sp(sp):
         fresh_browser.get(sp_shib_url(sp, append='mfa'))
@@ -227,7 +245,7 @@ def test_forget_me_self_service(utils, sp_url, sp_domain, secrets, netid3, test_
     """
     2FA-11 Forget me (self-service)
 
-    Only runs when running tests against prod, for now. Eval does not yet support the uw-rememberme cookie.
+    Only runs when running tests against prod, for now. Eval does not yet support a forget_me type of function.
     """
     idp_env = ''
     if test_env == "eval":

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -89,7 +89,7 @@ class TestNew2FASessionAndForcedReAuth:
             log_in_netid(self.browser, self.netid, assert_success=False)
             self.enter_duo_passcode(self.browser,
                                     passcode=passcode,
-                                    assert_failure=True)
+                                    assert_failure=True, is_this_your_device_screen=False)
             self.enter_duo_passcode(self.browser, select_duo_push=False, match_service_provider=sp, assert_success=True, retry=True)
 
     @pytest.mark.usefixtures('skip_if_eval')  # forced re-auth currently isn't in place at all for the same browser


### PR DESCRIPTION
Closes GH-41

- A number of adjustments were made to the tests, especially when run against eval, to accomodate the new "remember me" style cookie that is now generated by duo.
Code was also changed to:
- run the reauth tests (no longer skipped)
- look for and use the new "is this your device screen"
