### PR TITLE
[GH-46] update use of google-github-actions/upload-cloud-storage to v2

### DIFF
--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -193,7 +193,7 @@ jobs:
           path: web-tests
           destination: ${{ secrets.IDENTITY_ARTIFACT_BUCKET }}
         name: upload storyboards to identity-artifacts
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v2
 
       - if: ${{ always() && steps.run-tests.outputs.upload-artifacts == 'true' }}
         with:

--- a/.github/workflows/scheduled-idp-web-tests.yml
+++ b/.github/workflows/scheduled-idp-web-tests.yml
@@ -113,7 +113,7 @@ jobs:
       - if: always() && steps.post-run.outputs.upload_storyboards == 'true'
         name: Upload storyboards to identity-artifact
         id: upload-storyboards
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: 'web-tests'
           destination: ${{ secrets.IDENTITY_ARTIFACT_BUCKET }}


### PR DESCRIPTION
This is the second part to fixing the 3rd party software in the idp tests. 
The first part was [here](https://github.com/UWIT-IAM/uw-idp-web-tests/issues/45)  (update gcloud-configure-docker's use of google-github-actions/auth to v2)
Closes GH-46