### PR TITLE
[GH-50] Clear netid field before proceeding with the second test in class TestNew2FASessionAndForcedReAuth, update docker-compose call

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -165,4 +165,4 @@ then
   add_strict_host_override "$STRICT_HOST" "$STRICT_IP"
 fi
 COMPOSE_ARGS+=" $REQUIRED_COMPOSE_ARGS"
-docker-compose ${COMPOSE_ARGS}
+docker compose ${COMPOSE_ARGS}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,6 +296,7 @@ def log_in_netid(secrets: TestSecrets, sp_domain) -> Callable[..., NoReturn]:
             assert_success = password == default_password
         match_service_provider = sp_domain(match_service_provider) if match_service_provider else ''
         current_browser.wait_for_tag('p', 'Please sign in.')
+        current_browser.find_element(By.ID, "weblogin_netid").clear()
         current_browser.send_inputs(netid, password)
         current_browser.click(Locators.submit_button)
         if assert_success:

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -207,7 +207,11 @@ def test_remember_me_cookie(
         # shib_idp_session, shib_idp_session_ss
 
         cookie_names = {cookie['name'] for cookie in fresh_browser.get_cookies()}
-        assert 'shib_idp_session' in cookie_names
+        # prod and eval are different for about a week til the new shib is released to prod.
+        if test_env == 'eval':
+            assert '__Host-shib_idp_session' in cookie_names
+        else:
+            assert 'shib_idp_session' in cookie_names
         assert 'shib_idp_session_ss' in cookie_names
 
         fresh_browser.get(f'{sp_url(sp)}/Shibboleth.sso/Logout?return={idp_url}/profile/Logout')
@@ -215,7 +219,11 @@ def test_remember_me_cookie(
         fresh_browser.wait_for_tag('span', 'Your UW NetID sign-in session has ended.')
 
         cookie_names = {cookie['name'] for cookie in fresh_browser.get_cookies()}
-        assert 'shib_idp_session' not in cookie_names
+        # prod and eval are different for about a week til the new shib is released to prod.
+        if test_env == 'eval':
+            assert '__Host-shib_idp_session' not in cookie_names
+        else:
+            assert 'shib_idp_session' not in cookie_names
         assert 'shib_idp_session_ss' not in cookie_names
 
     sp = ServiceProviderInstance.diafine12

--- a/tests/test_2fa_duo.py
+++ b/tests/test_2fa_duo.py
@@ -101,6 +101,7 @@ class TestNew2FASessionAndForcedReAuth:
         sp = ServiceProviderInstance.diafine12
         with self.utils.using_test_sp(sp):
             self.browser.get(self.sp_shib_url(sp, append='mfaforce'))
+            self.browser.find_element(By.ID, "weblogin_netid").clear()
             self.browser.send_inputs(self.netid, self.password)
             self.browser.click(Locators.submit_button)
             self.enter_duo_passcode(self.browser, match_service_provider=sp, is_this_your_device_screen=False)


### PR DESCRIPTION
For some reason, we are retaining the netid from the prior test when we arrive at the next test in the class.
This change simply clears the form field containing the netid, then fills in the netid. This affected several tests.

The new shib on eval has different cookies and that is accounted for here.

`docker-compose` is replaced by `docker compose` in our cloud testing environment. If a programmer or other environment is on an older version of docker, switch `docker compose` to `docker-compose` for you local env only.

closes github issues: GH-52, GH-50