### PR TITLE
[GH-60] Replace slack notifications with Teams notifications on manually run GH test actions.

### DIFF
--- a/.github/scripts/configure-workflow.sh
+++ b/.github/scripts/configure-workflow.sh
@@ -133,6 +133,5 @@ function configure-workflow() {
   set-output idp-env "${INPUT_TARGET_IDP_ENV}"
   set-output idp-host "${INPUT_TARGET_IDP_HOST}"
   set-output run-tests-args "$(get-run-tests-args $artifact_object_path)"
-  set-output slack-channel "${INPUT_SLACK_CHANNEL:-#iam-bots}"
   set-output input-reason "$(get-input-reason)"
 }

--- a/.github/scripts/configure-workflow.sh
+++ b/.github/scripts/configure-workflow.sh
@@ -106,6 +106,18 @@ function get-run-tests-args() {
   echo "$payload"
 }
 
+function get-input-reason() {
+  # Determine the REASON
+  if [ -n "$INPUT_REASON" ]; then
+    REASON="$INPUT_REASON"
+  elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+    REASON="Triggered from PR"
+  else
+    REASON="No reason provided"
+  fi
+  echo "$REASON"
+}
+
 function configure-workflow() {
   local event_name="$GITHUB_EVENT_NAME"
   local actor="$GITHUB_ACTOR"
@@ -122,4 +134,5 @@ function configure-workflow() {
   set-output idp-host "${INPUT_TARGET_IDP_HOST}"
   set-output run-tests-args "$(get-run-tests-args $artifact_object_path)"
   set-output slack-channel "${INPUT_SLACK_CHANNEL:-#iam-bots}"
+  set-output input-reason "$(get-input-reason)"
 }

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Notify Teams of Test Run Start
         env:
           IDP_ENV: ${{ steps.configure.outputs.idp-env }}
+          INPUT_REASON: ${{ steps.configure.outputs.input-reason }}
         run: |
           curl -H "Content-Type: application/json" \
                -d '{
@@ -126,7 +127,8 @@ jobs:
                          {
                            "type": "FactSet",
                            "facts": [
-                               {"title": "IdP Web Tests running on ", "value": "'${{ env.IDP_ENV }}'"}
+                               {"title": "IdP Web Tests running on ", "value": "'${{ env.IDP_ENV }}'"},
+                               {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"}
                            ]
                          }
                        ]

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -228,7 +228,7 @@ jobs:
                                "type": "FactSet",
                                "facts": [
                                  {"title": "Storyboards:", "value": "['"$REPORT_URL"']('"$REPORT_URL"')"},
-                                 {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"}
+                                 {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"},
                                  {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}
                               ]
                              }

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -186,11 +186,12 @@ jobs:
 
       - name: Notify Teams of Test Run Completion
         env:
-          TEST_STATUS: ${{ env.test_status }}
+          TEST_STATUS: ${{ steps.run-tests.outputs.test-status }}
           REPORT_URL: ${{ steps.configure.outputs.report-url }}
         if: always()
         run: |
           # Set the message body dynamically based on TEST_STATUS
+          echo "TEST_STATUS TEST_STATUS TEST_STATUS TEST_STATUS TEST_STATUS=${{ env.TEST_STATUS }}"
           if [ "$TEST_STATUS" = "succeeded" ]; then
             test_result="Test run for IDP passed successfully ✅"
           else

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Notify Teams of Test Run Completion
         env:
-          TEST_STATUS: ${{ env.TEST_STATUS }}
+          TEST_STATUS: ${{ env.test_status }}
           REPORT_URL: ${{ steps.configure.outputs.report-url }}
         if: always()
         run: |

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -192,6 +192,7 @@ jobs:
           TEST_STATUS: ${{ steps.run-tests.outputs.test-status }}
           REPORT_URL: ${{ steps.configure.outputs.report-url }}
           INPUT_REASON: ${{ steps.configure.outputs.input-reason }}
+          IDP_ENV: ${{ steps.configure.outputs.idp-env }}
         if: always()
         run: |
           # Set the message body dynamically based on TEST_STATUS
@@ -231,7 +232,6 @@ jobs:
                                  {"title": "IdP Web Tests ran on ", "value": "'${{ env.IDP_ENV }}'"},
                                  {"title": "Reason for Test Run was ", "value": "${{ env.INPUT_REASON }}"},
                                  {"title": "Storyboards:", "value": "['"$REPORT_URL"']('"$REPORT_URL"')"},
-                                 {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"},
                                  {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}
                               ]
                              }

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -126,7 +126,6 @@ jobs:
                          {
                            "type": "FactSet",
                            "facts": [
-                               {"title": "IdP Web Tests running on ", "value": "['"$env.IDP_ENV"']('"$env.IDP_ENV"')"},
                                {"title": "IdP Web Tests running on ", "value": "'${{ env.IDP_ENV }}'"}
                            ]
                          }
@@ -184,3 +183,53 @@ jobs:
             - Test result: ${{ steps.run-tests.outcome }}
             - [Storyboards](${{ env.REPORT_URL }})
             **Commit ${{ env.SHORT_SHA }}**
+
+      - name: Notify Teams of Test Run Completion
+        env:
+          TEST_STATUS: ${{ env.TEST_STATUS }}
+          REPORT_URL: ${{ steps.configure.outputs.report-url }}
+        if: always()
+        run: |
+          # Set the message body dynamically based on TEST_STATUS
+          if [ "$TEST_STATUS" = "succeeded" ]; then
+            test_result="Test run for IDP passed successfully ✅"
+          else
+            test_result="Test run for IDP failed ❌"
+          fi
+
+          # Notify Teams with the status of the test run
+          curl -H "Content-Type: application/json" \
+               -d '{
+                     "type": "message",
+                     "attachments": [
+                       {
+                         "contentType": "application/vnd.microsoft.card.adaptive",
+                         "content": {
+                           "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                           "type": "AdaptiveCard",
+                           "version": "1.4",
+                           "body": [
+                             {
+                               "type": "TextBlock",
+                               "size": "Large",
+                               "weight": "Bolder",
+                               "text": "Test Run Notification"
+                             },
+                             {
+                               "type": "TextBlock",
+                               "text": "'"$test_result"'",
+                               "wrap": true
+                             },
+                             {
+                               "type": "FactSet",
+                               "facts": [
+                                 {"title": "Storyboards:", "value": "['"$REPORT_URL"']('"$REPORT_URL"')"},
+                                 {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}
+                              ]
+                             }
+                           ]
+                         }
+                       }
+                     ]
+                   }' \
+               "${{ secrets.TEAMS_INTEGRATIONS_DAILY_WEB_TESTS }}"

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -128,7 +128,8 @@ jobs:
                            "type": "FactSet",
                            "facts": [
                                {"title": "IdP Web Tests running on ", "value": "'${{ env.IDP_ENV }}'"},
-                               {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"}
+                               {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"},
+                               {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}
                            ]
                          }
                        ]

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -1,4 +1,4 @@
-name: No Slack - Run UW IdP Web Tests
+name: Run UW IdP Web Tests
 
 on:
   push:
@@ -117,11 +117,11 @@ jobs:
                            "type": "TextBlock",
                            "size": "Large",
                            "weight": "Bolder",
-                           "text": "Test Run Notification"
+                           "text": "IDP Test Run Notification"
                          },
                          {
                            "type": "TextBlock",
-                           "text": "Test run for UW IdP tests started ⏳",
+                           "text": "Starting - IDP Tests ⏳",
                            "wrap": true
                          },
                          {
@@ -195,7 +195,7 @@ jobs:
         if: always()
         run: |
           # Set the message body dynamically based on TEST_STATUS
-          echo "TEST_STATUS TEST_STATUS TEST_STATUS TEST_STATUS TEST_STATUS=${{ env.TEST_STATUS }}"
+          echo "TEST_STATUS=${{ env.TEST_STATUS }}"
           if [ "$TEST_STATUS" = "succeeded" ]; then
             test_result="Test run for IDP passed successfully ✅"
           else
@@ -218,7 +218,7 @@ jobs:
                                "type": "TextBlock",
                                "size": "Large",
                                "weight": "Bolder",
-                               "text": "Test Run Notification"
+                               "text": "Completed - IDP Test Run Notification"
                              },
                              {
                                "type": "TextBlock",
@@ -228,6 +228,8 @@ jobs:
                              {
                                "type": "FactSet",
                                "facts": [
+                                 {"title": "IdP Web Tests ran on ", "value": "'${{ env.IDP_ENV }}'"},
+                                 {"title": "Reason for Test Run was ", "value": "${{ env.INPUT_REASON }}"},
                                  {"title": "Storyboards:", "value": "['"$REPORT_URL"']('"$REPORT_URL"')"},
                                  {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"},
                                  {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -190,6 +190,7 @@ jobs:
         env:
           TEST_STATUS: ${{ steps.run-tests.outputs.test-status }}
           REPORT_URL: ${{ steps.configure.outputs.report-url }}
+          INPUT_REASON: ${{ steps.configure.outputs.input-reason }}
         if: always()
         run: |
           # Set the message body dynamically based on TEST_STATUS
@@ -227,6 +228,7 @@ jobs:
                                "type": "FactSet",
                                "facts": [
                                  {"title": "Storyboards:", "value": "['"$REPORT_URL"']('"$REPORT_URL"')"},
+                                 {"title": "Reason for Test Run", "value": "${{ env.INPUT_REASON }}"}
                                  {"title": "Initiated By:", "value": "'"${{ github.actor }}"'"}
                               ]
                              }

--- a/.github/workflows/automated-idp-web-tests.yml
+++ b/.github/workflows/automated-idp-web-tests.yml
@@ -43,6 +43,7 @@ env:
   ###############################################
   # Do not edit the env values below this line. #
   # Other defaults are set in .github/scripts/configure-workflow.sh
+  TEAMS_INTEGRATIONS_DAILY_WEB_TESTS: ${{ secrets.TEAMS_INTEGRATIONS_DAILY_WEB_TESTS }}
   ARTIFACT_BUCKET: ${{ secrets.IDENTITY_ARTIFACT_BUCKET }}
   ###############################################
 
@@ -95,6 +96,46 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
+
+      - name: Notify Teams of Test Run Start
+        env:
+          IDP_ENV: ${{ steps.configure.outputs.idp-env }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d '{
+                 "type": "message",
+                 "attachments": [
+                   {
+                     "contentType": "application/vnd.microsoft.card.adaptive",
+                     "content": {
+                       "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                       "type": "AdaptiveCard",
+                       "version": "1.4",
+                       "body": [
+                         {
+                           "type": "TextBlock",
+                           "size": "Large",
+                           "weight": "Bolder",
+                           "text": "Test Run Notification"
+                         },
+                         {
+                           "type": "TextBlock",
+                           "text": "Test run for UW IdP tests started ⏳",
+                           "wrap": true
+                         },
+                         {
+                           "type": "FactSet",
+                           "facts": [
+                               {"title": "IdP Web Tests running on ", "value": "['"$env.IDP_ENV"']('"$env.IDP_ENV"')"},
+                               {"title": "IdP Web Tests running on ", "value": "'${{ env.IDP_ENV }}'"}
+                           ]
+                         }
+                       ]
+                     }
+                   }
+                 ]
+               }' \
+               "${{ env.TEAMS_INTEGRATIONS_DAILY_WEB_TESTS }}"
 
       - env:
           RUN_TESTS_ARGS: ${{ steps.configure.outputs.run-tests-args }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,7 @@ services:
     volumes:
       - ${CREDENTIAL_MOUNT_POINT}:/secrets:ro
       - ${REPORT_MOUNT_POINT}:/tmp/webdriver-report
-    # command: pytest ${PYTEST_ARGS} tests/access_control/test_auto_2fa.py --selenium-server selenium:4444
-    # command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
-    command: echo "The test would start here"
+    command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
 
   selenium:
     image: selenium/standalone-chrome:4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     volumes:
       - ${CREDENTIAL_MOUNT_POINT}:/secrets:ro
       - ${REPORT_MOUNT_POINT}:/tmp/webdriver-report
-    # command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
-    command: echo "The test would start here"
+    command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
+    # command: echo "The test would start here" #If you don't want the tests to run, and test other things like notifications, use this command instead of the above.
 
   selenium:
     image: selenium/standalone-chrome:4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,8 @@ services:
     volumes:
       - ${CREDENTIAL_MOUNT_POINT}:/secrets:ro
       - ${REPORT_MOUNT_POINT}:/tmp/webdriver-report
-    command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
+    # command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
+    command: echo "The test would start here"
 
   selenium:
     image: selenium/standalone-chrome:4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,9 @@ services:
     volumes:
       - ${CREDENTIAL_MOUNT_POINT}:/secrets:ro
       - ${REPORT_MOUNT_POINT}:/tmp/webdriver-report
-    command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
+    # command: pytest ${PYTEST_ARGS} tests/access_control/test_auto_2fa.py --selenium-server selenium:4444
+    # command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444
+    command: echo "The test would start here"
 
   selenium:
     image: selenium/standalone-chrome:4

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -7,6 +7,7 @@ repository's [Github Actions UI]:
 - [Turn off the test SPs](#turn-off-the-test-service-providers)
 - [Generate IdP login requests](#generate-idp-login-requests)
 - [Re-build and re-cache the docker image](#re-build-and-re-cache-the-testing-docker-image)
+- [Debugging the Teams notifications and workflows](#debugging-the-teams-notifications-and-workflows)
 
 From the Actions UI, you can click on any workflow and then the "Run Workflow" button
 to get started. If a particular workflow does not have a "Run Workflow" button,
@@ -90,6 +91,15 @@ summary.
 
 ## Re-build and re-cache the testing docker image
 
+
+## Debugging the Teams notifications and workflows
+Sometime, you might find it handy to debug the workflows and not have the tests run.
+When you want to turn off the tests to debug some other part of the workflows, you can disable the test part.
+Go to [docker-compose.yml] (https://github.com/UWIT-IAM/uw-idp-web-tests/blob/mainline/docker-compose.yml)
+Remove the line `command: pytest ${PYTEST_ARGS} --selenium-server selenium:4444` and replace it with another command.
+You can replace to with `command: echo "The test would start here"`.
+That will not run the tests and instead, it will put an entry in the logs/terminal that says "The test would start here".
+You'll still see the test run and end notifications but the tests won't run.
 
 [test workflow]: https://github.com/UWIT-IAM/uw-idp-web-tests/actions/workflows/automated-idp-web-tests.yml
 [Github Actions UI]: https://github.com/uwit-iam/uw-idp-web-tests/actions

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -55,11 +55,6 @@ something, you might prefer to include the argument
 shutting down the test SP's. Just try to remember to run normally once so that the
 test SPs will be shut down when you're done!
 
-#### `slack-channel`
-
-The channel you want to send output to. This channel must have invited the Github
-Actions Crier (`/invite @iam-github-actions-crier`).
-
 ## Turn off the test Service Providers (SP's)
 
 The test SP's are turned on at the start of testing, but 

--- a/docs/test-service-providers.md
+++ b/docs/test-service-providers.md
@@ -13,7 +13,7 @@ them all off at the end of the session. This is convenient for the most common u
 running the entire test suite as a scheduled endeavor.
 
 However, the tests don't know if anyone else is running tests at the same time. Therefore, if running
-these manually, it might be a good idea to let the team know. The `#iam-accessmgmt` slack channel is a good place 
+these manually, it might be a good idea to let the team know. The `Access Management Practice` Teams channel is a good place
 to do that. Otherwise, you may shut down the test SPs while someone else is trying to use them (or vice-versa).
 
 ### Lazy SP Lifecycle Management


### PR DESCRIPTION
Closes GH-60
This will put a notification set into the teams channel when the idp tests are run manually. Next up, do the same, but for the scheduled tests :)
<img width="456" alt="image" src="https://github.com/user-attachments/assets/b71c12f1-99b1-425f-bb37-6f9a0b1ea5ea" />

